### PR TITLE
ci: upload coverage to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,15 @@ jobs:
       - name: Report coverage (enforces fail_under)
         run: uv run coverage report -m
 
+      - name: Generate XML report
+        run: uv run coverage xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Generate HTML report
         if: always()
         run: uv run coverage html -d htmlcov

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,11 +147,15 @@ Run specific test file:
 uv run pytest tests/test_wave.py
 ```
 
-Run with coverage:
+Run with coverage (matching CI):
 
 ```bash
-uv run pytest --cov=src/torchfx --cov-report=html
+uv run coverage run -m pytest
+uv run coverage report -m
+uv run coverage html -d htmlcov
 ```
+
+The CI coverage job also uploads `coverage.xml` to Codecov, which powers the coverage badge in the README.
 
 ### Writing Tests
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![arXiv](https://img.shields.io/badge/arXiv-2504.08624-b31b1b.svg)](https://arxiv.org/abs/2504.08624)
 [![PyPI version](https://badge.fury.io/py/torchfx.svg)](https://badge.fury.io/py/torchfx)
 ![PyPI - Status](https://img.shields.io/pypi/status/torchfx)
+[![codecov](https://codecov.io/gh/matteospanio/torchfx/branch/master/graph/badge.svg)](https://codecov.io/gh/matteospanio/torchfx)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/matteospanio/torchfx)
 
 **[Documentation](https://matteospanio.github.io/torchfx/)** | **[Getting Started](https://matteospanio.github.io/torchfx/guides/getting-started/getting_started.html)** | **[API Reference](https://matteospanio.github.io/torchfx/api/index.html)** | **[Blog](https://matteospanio.github.io/torchfx/blog/index.html)**


### PR DESCRIPTION
Fixes #27

## Summary
- add the Codecov badge to the README
- generate `coverage.xml` in the existing coverage job and upload it with `codecov/codecov-action`
- update the contributing guide's coverage commands to match the CI coverage workflow

## Validation
- `python3 - <<'PY' ... yaml.safe_load(open('.github/workflows/ci.yml')) ... PY` — passed
- `git diff --check` — passed
- `uv run pytest tests/test_logging.py` — failed locally on macOS/Python 3.10 due the existing timing assertion measuring ~0.200s for a 0.050s sleep; the latest upstream GitHub Actions runs are green on Linux
- `uv run coverage run -m pytest` — same local timing failure as above

## PR template
No pull request template found.
