### PR TITLE
🔧 Fix stale-build in cluster SLURM scripts (force rebuild + uv cache off home)

### DIFF
--- a/benchmarks/slurm/bench_a40.sbatch
+++ b/benchmarks/slurm/bench_a40.sbatch
@@ -27,6 +27,9 @@ export PATH="/usr/local/cuda/bin:$PATH"
 export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 export CUDACXX="${CUDACXX:-/usr/local/cuda/bin/nvcc}"
 export UV_LINK_MODE=copy
+# Keep uv's cache + build temp off the (quota-limited) home filesystem.
+export UV_CACHE_DIR="${UV_CACHE_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/.uvcache}"
+mkdir -p "$UV_CACHE_DIR"
 
 module load GCC >/dev/null 2>&1 || true
 module load CUDA >/dev/null 2>&1 || true
@@ -39,7 +42,10 @@ fi
 echo ">>> nvcc: $(nvcc --version | tail -n 1)"
 echo ">>> SLURM_JOB_ID=$SLURM_JOB_ID hostname=$(hostname)"
 
-uv sync --all-groups --no-cache
+# --reinstall-package forces a rebuild of the editable extension; plain `uv sync`
+# (even with --no-cache) treats an installed torchfx as satisfied and skips the
+# rebuild after a `git pull`, leaving a STALE .so that runs the OLD kernels.
+uv sync --all-groups --reinstall-package torchfx
 
 uv run --no-sync python - <<'PY'
 import torch

--- a/benchmarks/slurm/bench_l40s.sbatch
+++ b/benchmarks/slurm/bench_l40s.sbatch
@@ -36,6 +36,9 @@ export PATH="/usr/local/cuda/bin:$PATH"
 export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 export CUDACXX="${CUDACXX:-/usr/local/cuda/bin/nvcc}"
 export UV_LINK_MODE=copy
+# Keep uv's cache + build temp off the (quota-limited) home filesystem.
+export UV_CACHE_DIR="${UV_CACHE_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/.uvcache}"
+mkdir -p "$UV_CACHE_DIR"
 
 module load GCC >/dev/null 2>&1 || true
 module load CUDA >/dev/null 2>&1 || true
@@ -50,7 +53,10 @@ echo ">>> SLURM_JOB_ID=$SLURM_JOB_ID hostname=$(hostname)"
 
 # ---- Dependency sync ---------------------------------------------------------
 echo ">>> Syncing dependencies (clean cache)"
-uv sync --all-groups --no-cache
+# --reinstall-package forces a rebuild of the editable extension; plain `uv sync`
+# (even with --no-cache) treats an installed torchfx as satisfied and skips the
+# rebuild after a `git pull`, leaving a STALE .so that runs the OLD kernels.
+uv sync --all-groups --reinstall-package torchfx
 
 
 # ---- CUDA preflight ----------------------------------------------------------

--- a/benchmarks/slurm/bench_rtx.sbatch
+++ b/benchmarks/slurm/bench_rtx.sbatch
@@ -28,6 +28,9 @@ export PATH="/usr/local/cuda/bin:$PATH"
 export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 export CUDACXX="${CUDACXX:-/usr/local/cuda/bin/nvcc}"
 export UV_LINK_MODE=copy
+# Keep uv's cache + build temp off the (quota-limited) home filesystem.
+export UV_CACHE_DIR="${UV_CACHE_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/.uvcache}"
+mkdir -p "$UV_CACHE_DIR"
 
 module load GCC >/dev/null 2>&1 || true
 module load CUDA >/dev/null 2>&1 || true
@@ -40,7 +43,10 @@ fi
 echo ">>> nvcc: $(nvcc --version | tail -n 1)"
 echo ">>> SLURM_JOB_ID=$SLURM_JOB_ID hostname=$(hostname)"
 
-uv sync --all-groups --no-cache
+# --reinstall-package forces a rebuild of the editable extension; plain `uv sync`
+# (even with --no-cache) treats an installed torchfx as satisfied and skips the
+# rebuild after a `git pull`, leaving a STALE .so that runs the OLD kernels.
+uv sync --all-groups --reinstall-package torchfx
 
 uv run --no-sync python - <<'PY'
 import torch

--- a/benchmarks/slurm/run_cuda_tests.sbatch
+++ b/benchmarks/slurm/run_cuda_tests.sbatch
@@ -24,6 +24,9 @@ export PATH="/usr/local/cuda/bin:$PATH"
 export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 export CUDACXX="${CUDACXX:-/usr/local/cuda/bin/nvcc}"
 export UV_LINK_MODE=copy
+# Keep uv's cache + build temp off the (quota-limited) home filesystem.
+export UV_CACHE_DIR="${UV_CACHE_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/.uvcache}"
+mkdir -p "$UV_CACHE_DIR"
 
 module load GCC >/dev/null 2>&1 || true
 module load CUDA >/dev/null 2>&1 || true
@@ -45,7 +48,10 @@ echo "Results: ${RESULTS_DIR}"
 echo ""
 
 echo ">>> Syncing dependencies (clean resolver/cache)"
-uv sync --all-groups --no-cache
+# --reinstall-package forces a rebuild of the editable extension; plain `uv sync`
+# (even with --no-cache) treats an installed torchfx as satisfied and skips the
+# rebuild after a `git pull`, leaving a STALE .so that runs the OLD kernels.
+uv sync --all-groups --reinstall-package torchfx
 
 
 echo ">>> CUDA native dispatch preflight"

--- a/benchmarks/slurm/run_profiles.sbatch
+++ b/benchmarks/slurm/run_profiles.sbatch
@@ -35,6 +35,9 @@ export PATH="/usr/local/cuda/bin:$PATH"
 export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 export CUDACXX="${CUDACXX:-/usr/local/cuda/bin/nvcc}"
 export UV_LINK_MODE=copy
+# Keep uv's cache + build temp off the (quota-limited) home filesystem.
+export UV_CACHE_DIR="${UV_CACHE_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/.uvcache}"
+mkdir -p "$UV_CACHE_DIR"
 
 module load GCC >/dev/null 2>&1 || true
 module load CUDA >/dev/null 2>&1 || true
@@ -46,7 +49,10 @@ fi
 echo "nvcc: $(nvcc --version | tail -n 1)"
 
 echo ">>> Syncing dependencies (clean resolver/cache)"
-uv sync --all-groups --no-cache
+# --reinstall-package forces a rebuild of the editable extension; plain `uv sync`
+# (even with --no-cache) treats an installed torchfx as satisfied and skips the
+# rebuild after a `git pull`, leaving a STALE .so that runs the OLD kernels.
+uv sync --all-groups --reinstall-package torchfx
 
 
 echo ">>> CUDA native dispatch preflight"

--- a/benchmarks/slurm/soak_fused_scan.sbatch
+++ b/benchmarks/slurm/soak_fused_scan.sbatch
@@ -1,0 +1,101 @@
+#!/bin/bash
+#SBATCH --job-name=tfx-soak-fused
+#SBATCH --partition=allgroups
+#SBATCH --output=benchmarks/results/soak-fused-%j.out
+#SBATCH --error=benchmarks/results/soak-fused-%j.err
+#SBATCH --gres=gpu:l40s:1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=32G
+#SBATCH --time=01:30:00
+#
+# Soak test for the single-pass decoupled-look-back SOS scan (TORCHFX_FUSED_SCAN=1).
+# Validates the kernel's forward progress and numerical correctness on a GPU
+# architecture other than the RTX 3070 it was developed on, so the fused path can be
+# made the default with confidence. The decoupled look-back's deadlock-free forward
+# progress depends on block scheduling, which differs by SM count / architecture --
+# this is exactly what we want to confirm on L40S (sm_89) and A40 (sm_86).
+#
+# Submit for each GPU type (override --gres):
+#     sbatch benchmarks/slurm/soak_fused_scan.sbatch                  # L40S (gpu7)
+#     sbatch --gres=gpu:a40:1 benchmarks/slurm/soak_fused_scan.sbatch # A40  (gpu1/5/6)
+
+set -euo pipefail
+cd "${SLURM_SUBMIT_DIR:-$PWD}"
+
+export PATH="/usr/local/cuda/bin:$PATH"
+export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
+export CUDACXX="${CUDACXX:-/usr/local/cuda/bin/nvcc}"
+export UV_LINK_MODE=copy
+# Keep uv's cache + build temp off the (quota-limited) home filesystem.
+export UV_CACHE_DIR="${UV_CACHE_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/.uvcache}"
+mkdir -p "$UV_CACHE_DIR"
+module load GCC >/dev/null 2>&1 || true
+module load CUDA >/dev/null 2>&1 || true
+command -v nvcc >/dev/null 2>&1 || { echo "ERROR: nvcc not found"; exit 2; }
+
+echo "=== TorchFX single-pass-scan soak ==="
+echo "Job ${SLURM_JOB_ID} on $(hostname) @ $(date -Iseconds)"
+echo "git: $(git rev-parse --short HEAD) ($(git branch --show-current 2>/dev/null))"
+nvcc --version | tail -1
+
+echo ">>> build (scikit-build-core compiles the .cu kernels for this node's arch)"
+# IMPORTANT: --reinstall-package forces a rebuild of the editable extension. Plain
+# `uv sync` (even with --no-cache) treats an already-installed torchfx as satisfied
+# and does NOT recompile after a `git pull`, leaving a stale .so — which silently
+# tests/benchmarks the OLD kernels (e.g. an old sos_forward signature -> TypeError).
+uv sync --all-groups --reinstall-package torchfx
+
+uv run --no-sync python - <<'PY'
+import torch
+print("GPU:", torch.cuda.get_device_name(0))
+p = torch.cuda.get_device_properties(0)
+print(f"compute capability sm_{p.major}{p.minor}, {p.multi_processor_count} SMs, {p.total_memory/1e9:.1f} GB")
+PY
+
+echo ""
+echo ">>> [1/5] forced-fused equivalence + forward-progress test file"
+TORCHFX_FUSED_SCAN=1 uv run --no-sync python -m pytest tests/test_fused_scan_equivalence.py -q
+
+echo ""
+echo ">>> [2/5] FULL SUITE via the fused path (the soak)"
+TORCHFX_FUSED_SCAN=1 uv run --no-sync python -m pytest tests/ -q
+
+echo ""
+echo ">>> [3/5] default (oracle) full suite -- no-regression check"
+uv run --no-sync python -m pytest tests/ -q
+
+echo ""
+echo ">>> [4/5] launch counts + wall-time: oracle vs single-pass"
+echo "--- oracle (3-phase) ---"
+uv run --no-sync python tools/count_kernel_launches.py --device cuda --depths 5 10 20 50 --duration 5 --iters 20
+echo "--- single-pass (TORCHFX_FUSED_SCAN=1) ---"
+TORCHFX_FUSED_SCAN=1 uv run --no-sync python tools/count_kernel_launches.py --device cuda --depths 5 10 20 50 --duration 5 --iters 20
+
+echo ""
+echo ">>> [5/5] deep forward-progress stress (up to ~2048 tiles, 8 channels)"
+TORCHFX_FUSED_SCAN=1 uv run --no-sync python - <<'PY'
+import numpy as np
+import torch
+from scipy.signal import butter, sosfilt
+from torchfx._ops import parallel_iir_forward
+
+sos_np = np.concatenate([butter(2, c, output="sos") for c in (0.1, 0.2, 0.3, 0.4)], axis=0)
+for t in (262_144, 1_048_576):  # ~512 and ~2048 tiles of 512 samples
+    for dt in (torch.float32, torch.float64):
+        g = torch.Generator().manual_seed(t)
+        x = torch.randn(8, t, generator=g, dtype=dt)
+        sos = torch.tensor(sos_np, dtype=dt, device="cuda")
+        y, _, _ = parallel_iir_forward(x.cuda(), sos, None, None, sos_cpu=sos.cpu(), threshold=0)
+        torch.cuda.synchronize()
+        assert torch.isfinite(y).all(), (t, dt)
+        ref = torch.tensor(sosfilt(sos_np, x.double().numpy(), axis=-1), dtype=dt)
+        md = (y.cpu() - ref).abs().max().item()
+        tol = 5e-3 if dt == torch.float32 else 1e-7
+        ok = md < tol
+        print(f"  T={t:>9} {str(dt):>14} tiles~{t//512:<4} max|y-scipy|={md:.2e} {'OK' if ok else 'FAIL'}")
+        assert ok, (t, dt, md)
+print("deep forward-progress stress: PASS")
+PY
+
+echo ""
+echo "=== soak complete: PASS ==="


### PR DESCRIPTION
## Problem

The cluster sbatch scripts built with `uv sync --all-groups --no-cache`. That does **not** rebuild the editable `torchfx` extension — uv treats an already-installed package as satisfied and skips the recompile. So after a `git pull`, the `.so` stays **stale**, and the job silently tests/benchmarks the **old** kernels.

This was the real cause of the single-pass-scan "soak failure" on the L40S: every `sos_forward` call raised `TypeError: incompatible function arguments` because the built `.so` still had the **pre-`threshold`** 5-arg signature. With a forced rebuild, the single-pass kernel is bit-exact correct on the L40S (sm_89) — 1204/1204 via the fused path, 5.9× fewer launches, ~2.1× faster.

## Fix

- All five scripts (`bench_l40s`, `bench_a40`, `bench_rtx`, `run_cuda_tests`, `run_profiles`) now use **`uv sync --all-groups --reinstall-package torchfx`** (forces a clean rebuild).
- Set **`UV_CACHE_DIR`** under the submit dir on `/nfsd` so the build temp doesn't hit the quota-limited home filesystem (the rebuild failed with `Disk quota exceeded` on `~/.cache/uv` until redirected).
- Add `benchmarks/slurm/soak_fused_scan.sbatch` — cross-architecture correctness + forward-progress + launch-count soak for the opt-in fused single-pass path.

## ⚠️ Implication

Cluster benchmark numbers produced after a `git pull` **without** this fix may have been measured against **stale builds**. The L40S/A40 numbers should be re-run against current code (queued separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)