### PR TITLE
✨ Compressor dynamics effect (closes #30)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`Compressor` dynamics effect.** A feed-forward dynamic-range compressor with a
+  decoupled peak detector (release max-hold + attack one-pole), a soft-knee dB gain
+  curve (`threshold`/`ratio`/`knee`), `makeup_gain`, peak or RMS detection, and a
+  `ratio=inf` brick-wall limiter mode. Detection runs in a native per-channel
+  C++/CUDA kernel (`compressor_forward`). Usage: `wave | Compressor(threshold=-18,
+  ratio=4)`. (Resolves #30.)
 - **Single-pass SOS scan (kernel-level fusion).** A new GPU path folds each cascade
   section's forcing pass and the three-phase Blelloch scan into a **single
   decoupled-look-back kernel** (Merrill–Garland / CUB style, with an atomic

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,13 +82,15 @@ set(CSRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/torchfx/_csrc")
 Python_add_library(torchfx_ext MODULE WITH_SOABI
   "${CSRC_DIR}/binding.cpp"
   "${CSRC_DIR}/cpu/iir_cpu.cpp"
-  "${CSRC_DIR}/cpu/delay_cpu.cpp")
+  "${CSRC_DIR}/cpu/delay_cpu.cpp"
+  "${CSRC_DIR}/cpu/compressor_cpu.cpp")
 
 if(TORCHFX_USE_CUDA)
   target_sources(torchfx_ext PRIVATE
     "${CSRC_DIR}/cuda/parallel_scan.cu"
     "${CSRC_DIR}/cuda/biquad_forward.cu"
-    "${CSRC_DIR}/cuda/delay_forward.cu")
+    "${CSRC_DIR}/cuda/delay_forward.cu"
+    "${CSRC_DIR}/cuda/compressor_forward.cu")
   target_compile_definitions(torchfx_ext PRIVATE WITH_CUDA)
   set_target_properties(torchfx_ext PROPERTIES CUDA_ARCHITECTURES "${TORCHFX_CUDA_ARCHS}")
 endif()

--- a/src/torchfx/_csrc/binding.cpp
+++ b/src/torchfx/_csrc/binding.cpp
@@ -3,6 +3,7 @@
 #ifdef WITH_CUDA
 #include "torchfx/biquad_kernel.h"
 #include "torchfx/delay_kernel.h"
+#include "torchfx/compressor_kernel.h"
 #endif
 
 // CPU implementation declarations
@@ -25,6 +26,17 @@ torch::Tensor delay_line_forward_cpu(
     int delay_samples,
     double decay,
     double mix);
+
+torch::Tensor compressor_forward_cpu(
+    const torch::Tensor& x,
+    double threshold_db,
+    double inv_ratio,
+    double knee_db,
+    double makeup_db,
+    double attack_coeff,
+    double release_coeff,
+    double rms_coeff,
+    int detector);
 
 // Dispatch: select CUDA or CPU implementation based on tensor device.
 // `threshold` is the sequential-vs-parallel-scan boundary used by the CUDA path
@@ -86,6 +98,32 @@ torch::Tensor delay_line_forward(
   return delay_line_forward_cpu(x, delay_samples, decay, mix);
 }
 
+// Compressor dispatch. `inv_ratio` = 1/ratio (0 for an infinite-ratio limiter);
+// `detector` is 0=peak, 1=rms. Coefficients are precomputed by the Python layer
+// from attack/release/rms times and fs.
+torch::Tensor compressor_forward(
+    const torch::Tensor& x,
+    double threshold_db,
+    double inv_ratio,
+    double knee_db,
+    double makeup_db,
+    double attack_coeff,
+    double release_coeff,
+    double rms_coeff,
+    int detector) {
+#ifdef WITH_CUDA
+  if (x.is_cuda()) {
+    return torchfx::compressor_forward_cuda(x, threshold_db, inv_ratio, knee_db,
+                                            makeup_db, attack_coeff, release_coeff,
+                                            rms_coeff, detector);
+  }
+#else
+  TORCH_CHECK(!x.is_cuda(), "CUDA extension not compiled; move tensors to CPU");
+#endif
+  return compressor_forward_cpu(x, threshold_db, inv_ratio, knee_db, makeup_db,
+                                attack_coeff, release_coeff, rms_coeff, detector);
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("biquad_forward", &biquad_forward,
         "Biquad filter forward (CUDA/CPU)",
@@ -99,4 +137,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         "Delay line forward (CUDA only)",
         py::arg("x"), py::arg("delay_samples"),
         py::arg("decay"), py::arg("mix"));
+  m.def("compressor_forward", &compressor_forward,
+        "Compressor forward (CUDA/CPU)",
+        py::arg("x"), py::arg("threshold"), py::arg("inv_ratio"), py::arg("knee"),
+        py::arg("makeup_db"), py::arg("attack_coeff"), py::arg("release_coeff"),
+        py::arg("rms_coeff"), py::arg("detector"));
 }

--- a/src/torchfx/_csrc/cpu/compressor_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/compressor_cpu.cpp
@@ -1,0 +1,115 @@
+#include <torch/torch.h>
+#include <algorithm>
+#include <cmath>
+
+// CPU feed-forward compressor with a decoupled peak detector. One channel per
+// OpenMP thread, sequential over time (the ballistics are a nonlinear recurrence).
+// See include/torchfx/compressor_kernel.h for the per-sample math.
+
+#if defined(_MSC_VER)
+#define TORCHFX_RESTRICT __restrict
+#else
+#define TORCHFX_RESTRICT __restrict__
+#endif
+
+template <typename scalar_t>
+static void compressor_loop(
+    const scalar_t* TORCHFX_RESTRICT in_ptr,
+    scalar_t* TORCHFX_RESTRICT out_ptr,
+    int64_t C,
+    int64_t T,
+    scalar_t threshold_db,
+    scalar_t inv_ratio,
+    scalar_t knee_db,
+    scalar_t makeup_db,
+    scalar_t attack_coeff,
+    scalar_t release_coeff,
+    scalar_t rms_coeff,
+    int detector) {
+
+  const scalar_t eps = static_cast<scalar_t>(1e-12);
+  const scalar_t one = static_cast<scalar_t>(1);
+  const scalar_t two = static_cast<scalar_t>(2);
+  const scalar_t twenty = static_cast<scalar_t>(20);
+
+  #pragma omp parallel for schedule(static) if(C > 1)
+  for (int64_t c = 0; c < C; ++c) {
+    const scalar_t* in_c = in_ptr + c * T;
+    scalar_t* out_c = out_ptr + c * T;
+
+    scalar_t y1 = 0, yL = 0, ms = 0;
+    for (int64_t n = 0; n < T; ++n) {
+      const scalar_t xn = in_c[n];
+
+      scalar_t rect;
+      if (detector == 1) {  // RMS
+        ms = rms_coeff * ms + (one - rms_coeff) * xn * xn;
+        rect = std::sqrt(ms);
+      } else {  // peak
+        rect = std::abs(xn);
+      }
+
+      y1 = std::max(rect, release_coeff * y1);            // release max-hold
+      yL = attack_coeff * yL + (one - attack_coeff) * y1;  // attack one-pole
+
+      const scalar_t L = twenty * std::log10(std::max(yL, eps));
+      const scalar_t over = L - threshold_db;
+      scalar_t Lsc;
+      if (knee_db > 0 && two * std::abs(over) <= knee_db) {
+        const scalar_t t = over + knee_db / two;
+        Lsc = L + (inv_ratio - one) * t * t / (two * knee_db);
+      } else if (over > 0) {
+        Lsc = threshold_db + over * inv_ratio;
+      } else {
+        Lsc = L;
+      }
+
+      const scalar_t gdb = (Lsc - L) + makeup_db;
+      const scalar_t g = std::pow(static_cast<scalar_t>(10), gdb / twenty);
+      out_c[n] = g * xn;
+    }
+  }
+}
+
+torch::Tensor compressor_forward_cpu(
+    const torch::Tensor& x,
+    double threshold_db,
+    double inv_ratio,
+    double knee_db,
+    double makeup_db,
+    double attack_coeff,
+    double release_coeff,
+    double rms_coeff,
+    int detector) {
+
+  TORCH_CHECK(!x.is_cuda(), "compressor_forward_cpu: input must be on CPU");
+
+  auto x_cont = x.contiguous();
+  const int orig_dim = x_cont.dim();
+  if (orig_dim == 1) {
+    x_cont = x_cont.unsqueeze(0);
+  }
+
+  const int64_t C = x_cont.size(0);
+  const int64_t T = x_cont.size(1);
+  auto output = torch::empty_like(x_cont);
+
+  if (x_cont.dtype() == torch::kFloat32) {
+    compressor_loop<float>(
+        x_cont.data_ptr<float>(), output.data_ptr<float>(), C, T,
+        static_cast<float>(threshold_db), static_cast<float>(inv_ratio),
+        static_cast<float>(knee_db), static_cast<float>(makeup_db),
+        static_cast<float>(attack_coeff), static_cast<float>(release_coeff),
+        static_cast<float>(rms_coeff), detector);
+  } else {
+    compressor_loop<double>(
+        x_cont.data_ptr<double>(), output.data_ptr<double>(), C, T,
+        threshold_db, inv_ratio, knee_db, makeup_db,
+        attack_coeff, release_coeff, rms_coeff, detector);
+  }
+
+  if (orig_dim == 1) {
+    return output.squeeze(0);
+  }
+  return output;
+}

--- a/src/torchfx/_csrc/cuda/compressor_forward.cu
+++ b/src/torchfx/_csrc/cuda/compressor_forward.cu
@@ -1,0 +1,119 @@
+#include <torch/torch.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <c10/cuda/CUDAStream.h>
+#include "torchfx/compressor_kernel.h"
+
+// Feed-forward compressor with a decoupled peak detector. One thread per channel,
+// each walking its own time series sequentially (the ballistics are a nonlinear
+// recurrence — same topology as the sequential biquad). Templated on scalar_t so a
+// float32 input runs natively in FP32. See compressor_kernel.h for the math.
+
+namespace torchfx {
+
+template <typename scalar_t>
+__global__ void compressor_kernel(
+    const scalar_t* __restrict__ input,
+    scalar_t* __restrict__ output,
+    scalar_t threshold_db,
+    scalar_t inv_ratio,
+    scalar_t knee_db,
+    scalar_t makeup_db,
+    scalar_t attack_coeff,
+    scalar_t release_coeff,
+    scalar_t rms_coeff,
+    int detector,
+    int C,
+    int T) {
+
+  const int channel = blockIdx.x * blockDim.x + threadIdx.x;
+  if (channel >= C) return;
+
+  const scalar_t* in_c = input + static_cast<int64_t>(channel) * T;
+  scalar_t* out_c = output + static_cast<int64_t>(channel) * T;
+
+  const scalar_t eps = static_cast<scalar_t>(1e-12);
+  const scalar_t one = static_cast<scalar_t>(1);
+  const scalar_t two = static_cast<scalar_t>(2);
+  const scalar_t twenty = static_cast<scalar_t>(20);
+
+  scalar_t y1 = 0, yL = 0, ms = 0;
+  for (int n = 0; n < T; ++n) {
+    const scalar_t xn = in_c[n];
+
+    scalar_t rect;
+    if (detector == 1) {  // RMS
+      ms = rms_coeff * ms + (one - rms_coeff) * xn * xn;
+      rect = sqrt(ms);
+    } else {  // peak
+      rect = fabs(xn);
+    }
+
+    y1 = fmax(rect, release_coeff * y1);                 // release max-hold
+    yL = attack_coeff * yL + (one - attack_coeff) * y1;  // attack one-pole
+
+    const scalar_t L = twenty * log10(fmax(yL, eps));
+    const scalar_t over = L - threshold_db;
+    scalar_t Lsc;
+    if (knee_db > scalar_t(0) && two * fabs(over) <= knee_db) {
+      const scalar_t t = over + knee_db / two;
+      Lsc = L + (inv_ratio - one) * t * t / (two * knee_db);
+    } else if (over > scalar_t(0)) {
+      Lsc = threshold_db + over * inv_ratio;
+    } else {
+      Lsc = L;
+    }
+
+    const scalar_t gdb = (Lsc - L) + makeup_db;
+    const scalar_t g = pow(static_cast<scalar_t>(10), gdb / twenty);
+    out_c[n] = g * xn;
+  }
+}
+
+torch::Tensor compressor_forward_cuda(
+    const torch::Tensor& x,
+    double threshold_db,
+    double inv_ratio,
+    double knee_db,
+    double makeup_db,
+    double attack_coeff,
+    double release_coeff,
+    double rms_coeff,
+    int detector) {
+
+  TORCH_CHECK(x.is_cuda(), "compressor_forward_cuda: input must be on CUDA");
+
+  auto x_cont = x.contiguous();
+  int64_t C, T;
+  if (x_cont.dim() == 1) {
+    C = 1;
+    T = x_cont.size(0);
+    x_cont = x_cont.unsqueeze(0);
+  } else {
+    C = x_cont.size(0);
+    T = x_cont.size(1);
+  }
+
+  auto output = torch::empty_like(x_cont);
+
+  const int threads = 128;
+  const int blocks = (static_cast<int>(C) + threads - 1) / threads;
+  const auto stream = c10::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_FLOATING_TYPES(x_cont.scalar_type(), "compressor_forward_cuda", [&] {
+    compressor_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+        x_cont.data_ptr<scalar_t>(), output.data_ptr<scalar_t>(),
+        static_cast<scalar_t>(threshold_db), static_cast<scalar_t>(inv_ratio),
+        static_cast<scalar_t>(knee_db), static_cast<scalar_t>(makeup_db),
+        static_cast<scalar_t>(attack_coeff), static_cast<scalar_t>(release_coeff),
+        static_cast<scalar_t>(rms_coeff), detector,
+        static_cast<int>(C), static_cast<int>(T));
+  });
+
+  if (x.dim() == 1) {
+    return output.squeeze(0);
+  }
+  return output;
+}
+
+}  // namespace torchfx

--- a/src/torchfx/_csrc/include/torchfx/compressor_kernel.h
+++ b/src/torchfx/_csrc/include/torchfx/compressor_kernel.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <torch/types.h>
+
+namespace torchfx {
+
+// Feed-forward dynamic-range compressor with a decoupled peak detector.
+//
+// Per channel, sequentially over time n:
+//   rect = |x[n]|                              (detector=0, peak)
+//   ms   = rms_coeff*ms + (1-rms_coeff)*x^2;  rect = sqrt(ms)  (detector=1, rms)
+//   y1   = max(rect, release_coeff * y1)       (release max-hold)
+//   yL   = attack_coeff*yL + (1-attack_coeff)*y1   (attack one-pole)
+//   L    = 20*log10(max(yL, eps))
+//   gain curve (threshold_db, inv_ratio, knee_db) -> Lsc
+//   g    = 10^((Lsc - L + makeup_db)/20);  y[n] = g * x[n]
+//
+// `inv_ratio` is 1/ratio (0 for an infinite-ratio limiter, avoiding inf math).
+torch::Tensor compressor_forward_cuda(
+    const torch::Tensor& x,
+    double threshold_db,
+    double inv_ratio,
+    double knee_db,
+    double makeup_db,
+    double attack_coeff,
+    double release_coeff,
+    double rms_coeff,
+    int detector);
+
+}  // namespace torchfx

--- a/src/torchfx/_ops.py
+++ b/src/torchfx/_ops.py
@@ -276,3 +276,59 @@ def delay_line_forward(
     if len(original_shape) == 2:
         return result_2d
     return result_2d.reshape(original_shape)
+
+
+def compressor_forward(
+    x: Tensor,
+    threshold_db: float,
+    inv_ratio: float,
+    knee_db: float,
+    makeup_db: float,
+    attack_coeff: float,
+    release_coeff: float,
+    rms_coeff: float,
+    detector: int,
+) -> Tensor:
+    """Dispatch the compressor to the native kernel (CUDA or CPU).
+
+    Ballistics coefficients are precomputed by the caller. ``detector`` is 0 (peak)
+    or 1 (rms); ``inv_ratio`` is ``1 / ratio`` (0 for an infinite-ratio limiter, so
+    the kernel never does ``inf`` arithmetic). Returns the processed tensor with the
+    input shape and dtype preserved.
+
+    """
+    if x.ndim < 1:
+        raise ValueError("Input tensor must have at least 1 dimension.")
+    if not x.is_floating_point():
+        raise TypeError("Input tensor must use a floating-point dtype.")
+
+    original_shape = x.shape
+    if x.ndim == 1:
+        x_2d = x.unsqueeze(0)
+    elif x.ndim == 2:
+        x_2d = x
+    else:
+        x_2d = x.reshape(-1, x.size(-1))
+
+    # Keep native kernels on their supported dtypes (float16/bfloat16 -> float32).
+    native_dtype = torch.float64 if x_2d.dtype == torch.float64 else torch.float32
+    x_native = x_2d if x_2d.dtype == native_dtype else x_2d.to(dtype=native_dtype)
+
+    result_native: Tensor = _ext.compressor_forward(
+        x_native,
+        threshold_db,
+        inv_ratio,
+        knee_db,
+        makeup_db,
+        attack_coeff,
+        release_coeff,
+        rms_coeff,
+        detector,
+    )
+    result_2d = result_native if result_native.dtype == x.dtype else result_native.to(dtype=x.dtype)
+
+    if len(original_shape) == 1:
+        return result_2d.squeeze(0)
+    if len(original_shape) == 2:
+        return result_2d
+    return result_2d.reshape(original_shape)

--- a/src/torchfx/effect.py
+++ b/src/torchfx/effect.py
@@ -1560,3 +1560,194 @@ class Delay(FX):
 
         # Wet/dry mix — fused via lerp (single kernel, avoids intermediates).
         return torch.lerp(waveform, delayed, self.mix)
+
+
+class Compressor(FX):
+    r"""Feed-forward dynamic-range compressor with a decoupled peak detector.
+
+    Reduces the dynamic range of a signal: levels above ``threshold`` are turned
+    down according to ``ratio``, with a soft ``knee`` around the threshold and
+    attack/release ballistics that control how quickly the gain reacts. An optional
+    ``makeup_gain`` restores overall loudness.
+
+    The side-chain level is tracked with a *decoupled* peak detector (a release
+    max-hold followed by an attack one-pole), the standard high-quality topology
+    (Giannoulis, Massberg & Reiss, 2012). Detection runs in native C++/CUDA, one
+    channel per thread.
+
+    Parameters
+    ----------
+    threshold : float, default=-20.0
+        Level above which compression begins, in **dBFS** (decibels relative to a
+        full-scale amplitude of 1.0).
+    ratio : float, default=4.0
+        Input/output ratio above the threshold (``>= 1.0``). ``4.0`` means 4 dB in
+        yields 1 dB out over threshold. ``float("inf")`` is a brick-wall limiter.
+    attack : float, default=0.005
+        Attack time in **seconds** (how fast gain reduction engages). ``0`` is
+        instantaneous.
+    release : float, default=0.05
+        Release time in **seconds** (how fast gain recovers). ``0`` is instantaneous.
+    knee : float, default=6.0
+        Full width of the soft knee in **dB**, centred on the threshold. ``0`` gives
+        a hard knee.
+    makeup_gain : float, default=0.0
+        Output gain applied after compression, in **dB**.
+    detector : {"peak", "rms"}, default="peak"
+        Side-chain level detection. ``"peak"`` follows ``|x|``; ``"rms"`` follows a
+        smoothed root-mean-square (averaging window tied to ``attack``).
+    fs : int or None, default=None
+        Sampling rate in Hz. May be left ``None`` and supplied lazily by a ``Wave``
+        pipeline (``wave | compressor``); the ballistics coefficients are then
+        derived from the times and ``fs`` on first ``forward``.
+
+    Returns
+    -------
+    Tensor
+        The compressed waveform, same shape and dtype as the input.
+
+    Raises
+    ------
+    ValueError
+        If ``ratio < 1``, ``attack``/``release``/``knee`` is negative, ``detector``
+        is not ``"peak"``/``"rms"``, ``fs`` is non-positive, or ``forward`` is called
+        before ``fs`` is known.
+
+    See Also
+    --------
+    Gain : Static volume adjustment.
+    Normalize : Amplitude normalization.
+
+    Notes
+    -----
+    Per channel, sequentially over samples :math:`n` (linear detector level, then
+    the gain computed in dB):
+
+    .. math::
+
+        \text{rect}[n] &= |x[n]| \quad (\text{peak}) \\
+        y_1[n] &= \max(\text{rect}[n],\ a_R\, y_1[n-1]) \\
+        y_L[n] &= a_A\, y_L[n-1] + (1 - a_A)\, y_1[n] \\
+        L &= 20 \log_{10}(\max(y_L[n], \epsilon))
+
+    with attack/release coefficients :math:`a_A = e^{-1/(\text{attack}\cdot f_s)}`,
+    :math:`a_R = e^{-1/(\text{release}\cdot f_s)}`. The static curve (soft knee of
+    width :math:`W` centred on threshold :math:`T`, ``r`` = ratio) maps :math:`L` to
+    :math:`L_{sc}`, and the per-sample gain is
+    :math:`g[n] = 10^{(L_{sc} - L + \text{makeup})/20}`, applied as
+    :math:`y[n] = g[n]\, x[n]`.
+
+    This is a **zero-latency feed-forward** design (no look-ahead). The ballistics
+    state is reset on each ``forward`` call, so block-wise streaming is *not*
+    state-continuous across chunks (a follow-up could thread the state in/out).
+
+    Examples
+    --------
+    Compress a signal 4:1 above -12 dBFS:
+
+    >>> import torch
+    >>> from torchfx.effect import Compressor
+    >>> x = torch.randn(2, 48000) * 0.5  # (channels, samples)
+    >>> comp = Compressor(threshold=-12.0, ratio=4.0, attack=0.005, release=0.08, fs=48000)
+    >>> y = comp(x)
+    >>> y.shape
+    torch.Size([2, 48000])
+
+    Use in a ``Wave`` pipeline (``fs`` is supplied automatically):
+
+    >>> import torchfx as fx
+    >>> processed = wave | fx.effect.Compressor(threshold=-18.0, ratio=3.0)  # doctest: +SKIP
+
+    Brick-wall limiting at -1 dBFS with makeup gain:
+
+    >>> limiter = Compressor(threshold=-1.0, ratio=float("inf"), makeup_gain=1.0, fs=48000)
+
+    References
+    ----------
+    D. Giannoulis, M. Massberg, J. D. Reiss, "Digital Dynamic Range Compressor
+    Design — A Tutorial and Analysis," J. Audio Eng. Soc., 60(6), 2012.
+
+    """
+
+    def __init__(
+        self,
+        threshold: float = -20.0,
+        ratio: float = 4.0,
+        attack: float = 0.005,
+        release: float = 0.05,
+        knee: float = 6.0,
+        makeup_gain: float = 0.0,
+        detector: str = "peak",
+        fs: int | None = None,
+    ) -> None:
+        super().__init__()
+        valid_detectors = {"peak", "rms"}
+        if detector not in valid_detectors:
+            raise ValueError(
+                f"detector must be one of {sorted(valid_detectors)}, got {detector!r}."
+            )
+        if ratio < 1.0:
+            raise ValueError(f"ratio must be >= 1.0, got {ratio}.")
+        if attack < 0:
+            raise ValueError(f"attack must be non-negative (seconds), got {attack}.")
+        if release < 0:
+            raise ValueError(f"release must be non-negative (seconds), got {release}.")
+        if knee < 0:
+            raise ValueError(f"knee must be non-negative (dB), got {knee}.")
+        if fs is not None and fs <= 0:
+            raise ValueError(f"Sample rate (fs) must be positive, got {fs}.")
+
+        self.threshold = float(threshold)
+        self.ratio = float(ratio)
+        self.attack = float(attack)
+        self.release = float(release)
+        self.knee = float(knee)
+        self.makeup_gain = float(makeup_gain)
+        self.detector = detector
+        self.fs = fs
+
+        # 1/ratio (0 for an inf-ratio limiter) so the kernel never does inf math.
+        self._inv_ratio = 0.0 if math.isinf(self.ratio) else 1.0 / self.ratio
+        self._aA = 0.0
+        self._aR = 0.0
+        self._aRMS = 0.0
+        self._last_fs: int | None = None
+        self._needs_calculation = True
+
+    def _compute_coeffs(self) -> None:
+        """Derive attack/release/RMS coefficients from the times and ``fs``."""
+        assert self.fs is not None
+        fs = self.fs
+        self._aA = 0.0 if self.attack == 0 else math.exp(-1.0 / (self.attack * fs))
+        self._aR = 0.0 if self.release == 0 else math.exp(-1.0 / (self.release * fs))
+        # The RMS averaging window defaults to the attack time.
+        self._aRMS = 0.0 if self.attack == 0 else math.exp(-1.0 / (self.attack * fs))
+        self._last_fs = fs
+        self._needs_calculation = False
+
+    @override
+    @torch.no_grad()
+    def forward(self, waveform: Tensor) -> Tensor:
+        if self._needs_calculation or self._last_fs != self.fs:
+            if self.fs is None:
+                raise ValueError(
+                    "Sample rate (fs) is required for the compressor. Use it in a "
+                    "Wave pipeline (wave | compressor) or pass fs at construction."
+                )
+            if self.fs <= 0:
+                raise ValueError("Sample rate (fs) must be positive.")
+            self._compute_coeffs()
+
+        from torchfx._ops import compressor_forward
+
+        return compressor_forward(
+            waveform,
+            self.threshold,
+            self._inv_ratio,
+            self.knee,
+            self.makeup_gain,
+            self._aA,
+            self._aR,
+            self._aRMS,
+            1 if self.detector == "rms" else 0,
+        )

--- a/tests/test_compressor.py
+++ b/tests/test_compressor.py
@@ -1,0 +1,218 @@
+"""Tests for the Compressor dynamics effect (issue #30)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from torchfx.effect import Compressor
+
+FS = 48000
+
+
+def _static_gain_db(level_db: float, threshold: float, ratio: float, knee: float) -> float:
+    """Reference static gain-reduction curve (matches the kernel, in dB)."""
+    inv_ratio = 0.0 if math.isinf(ratio) else 1.0 / ratio
+    over = level_db - threshold
+    if knee > 0 and 2 * abs(over) <= knee:
+        t = over + knee / 2
+        lsc = level_db + (inv_ratio - 1) * t * t / (2 * knee)
+    elif over > 0:
+        lsc = threshold + over * inv_ratio
+    else:
+        lsc = level_db
+    return lsc - level_db
+
+
+def _const(amp: float, n: int = 2048, c: int = 1, dtype=torch.float64) -> torch.Tensor:
+    return torch.full((c, n), amp, dtype=dtype)
+
+
+# --------------------------------------------------------------------------- #
+# Static gain curve (attack=release=0 -> instantaneous detector = |x|)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("level_db", [-30.0, -20.0, -12.0, -6.0, 0.0])
+@pytest.mark.parametrize("ratio", [2.0, 4.0, 10.0])
+@pytest.mark.parametrize("knee", [0.0, 6.0])
+def test_static_curve_matches_reference(level_db, ratio, knee):
+    threshold = -18.0
+    amp = 10 ** (level_db / 20)
+    comp = Compressor(threshold=threshold, ratio=ratio, attack=0.0, release=0.0, knee=knee, fs=FS)
+    y = comp(_const(amp))
+    g_db = _static_gain_db(level_db, threshold, ratio, knee)
+    expected = amp * 10 ** (g_db / 20)
+    torch.testing.assert_close(y, torch.full_like(y, expected), rtol=1e-5, atol=1e-7)
+
+
+def test_below_threshold_is_unity():
+    comp = Compressor(threshold=-12.0, ratio=4.0, attack=0.0, release=0.0, knee=0.0, fs=FS)
+    x = _const(10 ** (-24.0 / 20))  # well below threshold
+    torch.testing.assert_close(comp(x), x, rtol=1e-6, atol=1e-9)
+
+
+def test_limiter_clamps_at_threshold():
+    threshold = -10.0
+    comp = Compressor(
+        threshold=threshold, ratio=float("inf"), attack=0.0, release=0.0, knee=0.0, fs=FS
+    )
+    for level_db in (-5.0, 0.0, 6.0):
+        amp = 10 ** (level_db / 20)
+        y = comp(_const(amp))
+        out_db = 20 * math.log10(float(y.abs().max()))
+        assert out_db == pytest.approx(threshold, abs=1e-4)
+
+
+def test_makeup_gain_on_uncompressed():
+    comp = Compressor(
+        threshold=-6.0, ratio=4.0, attack=0.0, release=0.0, knee=0.0, makeup_gain=6.0, fs=FS
+    )
+    x = _const(10 ** (-30.0 / 20))  # below threshold -> only makeup applies
+    torch.testing.assert_close(comp(x), x * 10 ** (6.0 / 20), rtol=1e-5, atol=1e-8)
+
+
+def test_soft_knee_continuous():
+    # Sweep input level across the knee; the gain-reduction curve must be continuous.
+    threshold, ratio, knee = -18.0, 4.0, 8.0
+    comp = Compressor(threshold=threshold, ratio=ratio, attack=0.0, release=0.0, knee=knee, fs=FS)
+    prev = None
+    for level_db in [threshold + d for d in torch.linspace(-6, 6, 25).tolist()]:
+        amp = 10 ** (level_db / 20)
+        out_db = 20 * math.log10(float(comp(_const(amp)).abs().max()))
+        gr = out_db - level_db
+        if prev is not None:
+            assert abs(gr - prev) < 0.6  # no discontinuity across the knee
+        prev = gr
+
+
+# --------------------------------------------------------------------------- #
+# Ballistics
+# --------------------------------------------------------------------------- #
+def test_attack_smoothing_ramps_in():
+    # Loud step: gain reduction engages over ~attack, so the onset sample is louder
+    # (less reduction) than the settled region.
+    comp = Compressor(threshold=-20.0, ratio=8.0, attack=0.02, release=0.05, knee=0.0, fs=FS)
+    x = _const(10 ** (-3.0 / 20), n=4096)
+    y = comp(x).abs()
+    assert float(y[0, 0]) > float(y[0, -1]) + 1e-4  # onset less compressed than settled
+
+
+def test_release_recovers_after_loud():
+    # loud (compressed) -> silence: the held gain reduction recovers over ~release.
+    comp = Compressor(threshold=-20.0, ratio=8.0, attack=0.001, release=0.05, knee=0.0, fs=FS)
+    loud = 10 ** (-3.0 / 20)
+    # Tail long enough for the held level (-3 dBFS) to decay below threshold (-20 dB).
+    x = torch.cat([_const(loud, n=2000), _const(1e-4, n=16000)], dim=1)
+    y = comp(x)
+    quiet = y[:, 2000:]
+    # gain (out/in) over the quiet tail rises back toward unity as the hold releases.
+    gain = (quiet.abs() / 1e-4)[0]
+    assert float(gain[-1]) > float(gain[0])  # recovers
+    assert float(gain[0]) < 0.5  # starts compressed (~8:1 at -3 dBFS over -20 dB)
+    assert float(gain[-1]) == pytest.approx(1.0, abs=1e-2)  # fully recovered
+
+
+def test_coefficient_formula():
+    comp = Compressor(attack=0.01, release=0.1, fs=FS)
+    comp(_const(0.1))  # triggers coeff computation
+    assert comp._aA == pytest.approx(math.exp(-1.0 / (0.01 * FS)))
+    assert comp._aR == pytest.approx(math.exp(-1.0 / (0.1 * FS)))
+
+
+# --------------------------------------------------------------------------- #
+# Detector modes
+# --------------------------------------------------------------------------- #
+def test_rms_less_reduction_than_peak_on_sine():
+    t = torch.arange(FS, dtype=torch.float64) / FS
+    x = (0.7 * torch.sin(2 * math.pi * 1000 * t)).unsqueeze(0)
+    peak = Compressor(threshold=-20.0, ratio=4.0, detector="peak", fs=FS)(x)
+    rms = Compressor(threshold=-20.0, ratio=4.0, detector="rms", fs=FS)(x)
+    # RMS of a sine is ~3 dB below its peak, so it compresses less (louder output).
+    assert float(rms.abs().mean()) > float(peak.abs().mean())
+
+
+# --------------------------------------------------------------------------- #
+# Shapes / dtypes / device
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("shape", [(2048,), (2, 2048), (3, 2, 2048)])
+def test_shape_preserved(shape):
+    comp = Compressor(threshold=-12.0, ratio=4.0, fs=FS)
+    x = torch.randn(*shape) * 0.5
+    assert comp(x).shape == x.shape
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_dtype_preserved(dtype):
+    comp = Compressor(threshold=-12.0, ratio=4.0, fs=FS)
+    x = (torch.randn(2, 1024) * 0.5).to(dtype)
+    assert comp(x).dtype == dtype
+
+
+def test_identical_channels_identical_output():
+    comp = Compressor(threshold=-15.0, ratio=4.0, attack=0.003, release=0.05, fs=FS)
+    ch = torch.randn(1, 4096) * 0.6
+    y = comp(torch.cat([ch, ch], dim=0))
+    torch.testing.assert_close(y[0], y[1])
+
+
+def test_silent_input_silent_output():
+    comp = Compressor(threshold=-20.0, ratio=4.0, fs=FS)
+    x = torch.zeros(2, 1024)
+    assert torch.all(comp(x) == 0)
+
+
+# --------------------------------------------------------------------------- #
+# fs propagation
+# --------------------------------------------------------------------------- #
+def test_fs_required_without_pipeline():
+    comp = Compressor(threshold=-12.0, ratio=4.0)  # no fs
+    with pytest.raises(ValueError, match=r"Sample rate \(fs\) is required"):
+        comp(torch.randn(1, 256))
+
+
+def test_fs_set_via_attribute_recomputes():
+    comp = Compressor(attack=0.01, fs=44100)
+    comp(_const(0.1))
+    a1 = comp._aA
+    comp.fs = 48000  # mimics Wave.__update_config
+    comp(_const(0.1))
+    assert comp._aA != a1
+    assert comp._aA == pytest.approx(math.exp(-1.0 / (0.01 * 48000)))
+
+
+# --------------------------------------------------------------------------- #
+# Validation
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"ratio": 0.5},
+        {"attack": -0.1},
+        {"release": -0.1},
+        {"knee": -1.0},
+        {"detector": "median"},
+        {"fs": 0},
+        {"fs": -48000},
+    ],
+)
+def test_invalid_params_raise(kwargs):
+    with pytest.raises(ValueError):
+        Compressor(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# CPU / CUDA parity
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("detector", ["peak", "rms"])
+@pytest.mark.parametrize("ratio", [4.0, float("inf")])
+def test_cpu_cuda_parity(detector, ratio):
+    g = torch.Generator().manual_seed(0)
+    x = torch.randn(3, 4096, generator=g, dtype=torch.float32) * 0.6
+    comp = Compressor(
+        threshold=-18.0, ratio=ratio, attack=0.004, release=0.06, detector=detector, fs=FS
+    )
+    y_cpu = comp(x)
+    y_cuda = comp(x.cuda()).cpu()
+    torch.testing.assert_close(y_cuda, y_cpu, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
Implements the **Compressor** dynamics effect — the v0.7.0 milestone's headline dynamics processor (issue #30).

## What

A feed-forward dynamic-range compressor with a **decoupled peak detector** (the standard high-quality topology, Giannoulis et al. 2012):

`rect=|x|` (or RMS) → release max-hold `y1[n]=max(rect, aR·y1[n-1])` → attack one-pole `yL[n]=aA·yL[n-1]+(1-aA)·y1[n]` → soft-knee dB gain curve (`threshold`/`ratio`/`knee`) → `makeup_gain` → `y=g·x`.

- **`torchfx.effect.Compressor(threshold=-20 dBFS, ratio=4, attack=0.005 s, release=0.05 s, knee=6 dB, makeup_gain=0 dB, detector="peak"|"rms", fs=None)`** — dB/seconds units per repo conventions, lazy `fs` (Wave pipeline), NumPy docstring with the per-sample math + a runnable example. `ratio=inf` is a brick-wall limiter (encoded as `inv_ratio=0` so the kernel never does `inf` math).
- **Native per-channel sequential kernel `compressor_forward`** — the ballistics are a nonlinear recurrence, so one-thread/channel is the clean fast path (mirrors the sequential biquad / delay). CPU: OpenMP-over-channels (`cpu/compressor_cpu.cpp`); CUDA: templated on `scalar_t`, current-stream launch (`cuda/compressor_forward.cu`). Wired through `binding.cpp`, `_ops.compressor_forward`, `CMakeLists.txt`.

## Tests / validation

`tests/test_compressor.py` (54 cases): static gain curve vs an independent reference (parametrized over level/ratio/knee), below-threshold unity, limiter clamping, makeup gain, soft-knee continuity, attack/release ballistics direction, peak-vs-RMS, shapes/dtypes (1-D/2-D/3-D, f32/f64), `fs` propagation + lazy recompute, validation guards, and a CPU↔CUDA parity test.

- ✅ **CPU build + tests green locally** (`TORCHFX_NO_CUDA=1`): 54 compressor tests pass; **full suite 1187 passed** (no regression).
- ⏳ **CUDA parity not yet run** — my SSH to the GPU hosts is temporarily blocked (a local ssh-agent key issue cascaded into a login rate-limit). The CUDA kernel is a line-for-line mirror of the validated CPU kernel (identical per-sample math; only the per-channel parallelization differs) and the `test_cpu_cuda_parity` cases will confirm it. **I'll run the GPU build + parity before this is merged.** CI builds CPU-only, so it exercises the CPU path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)