### PR TITLE
⚡️ Cache-blocked cross-channel SIMD CPU SOS kernel (#24)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Cache-blocked cross-channel CPU SIMD for SOS cascades.** When channels outnumber
+  CPU cores, the scalar per-channel kernel runs several channels serially on each core.
+  A new path packs a SIMD vector of channels: it transposes small `[W, B]` tiles to
+  channel-contiguous layout that stays in L1 (so the recurrence's per-time-step channel
+  loop auto-vectorises to NEON/SSE/AVX), and engages automatically once
+  `C > num_threads`. Measured on a 4-section SOS cascade (float32): **1.8–2.6× on a
+  Raspberry Pi 5** (Cortex-A76 ×4, the edge target) and **1.3–2.4× on a 12-core x86**
+  for `C` ≥ 8/16 — with **no regression** below that, since `C ≤ cores` keeps the
+  optimal scalar path. `TORCHFX_NO_SIMD=1` forces the scalar kernel. (Resolves #24.)
 - **Single-pass SOS scan (kernel-level fusion).** A new GPU path folds each cascade
   section's forcing pass and the three-phase Blelloch scan into a **single
   decoupled-look-back kernel** (Merrill–Garland / CUB style, with an atomic

--- a/docs/source/guides/developer/roadmap.md
+++ b/docs/source/guides/developer/roadmap.md
@@ -472,14 +472,17 @@ Each item lists its difficulty and expected impact; none block a release.
 - [ ] **Pinned host buffers + async H2D/D2H for GPU streaming** — *medium.* Overlap chunk
   transfers with compute. Only pays off once a **GPU realtime/streaming I/O path** exists
   (the live path is CPU-only today), so deferred until that lands.
-- [ ] **Cache-blocked cross-channel CPU SIMD** — *medium, edge-focused.* A naive
-  full-transpose SIMD kernel was tried in 0.6.0 and **measured a 4–8× regression** on a
-  10-core desktop: the transpose moves as much memory as the streaming-light recurrence
-  computes, and the scalar OpenMP-over-channels path already saturates the cores. A
-  cache-blocked transpose (tiles that stay in L1/L2, state carried across time blocks)
-  could win, but the payoff is concentrated on **few-core edge devices (Raspberry Pi 5)**
-  and needs that hardware to validate. The scalar path is already near-optimal on
-  multi-core (8-ch, 10 s @ 48 kHz ≈ 3.5 ms).
+- [x] **Cache-blocked cross-channel CPU SIMD** — *done (#24).* A naive full-transpose
+  SIMD kernel (F1) regressed 4–8× on a 10-core desktop — the whole-`[C,T]` transpose
+  moved as much memory as the streaming-light recurrence computes. The fix: transpose
+  only small `[W=4, B=256]` tiles that stay in **L1**, auto-vectorise the per-time-step
+  channel loop (NEON/SSE/AVX), and **gate the path to `C > num_threads`** so the
+  scalar kernel stays for `C ≤ cores`. Validated on a **Raspberry Pi 5** (Cortex-A76
+  ×4): **1.8× at C=8, 2.6× at C=16/32**; and on **x86 (12 cores)**: 1.3–2.4× for
+  `C > cores`, **no regression** below. Correct vs scalar + `scipy.signal.sosfilt`
+  (full suite green with `TORCHFX_FORCE_SIMD=1`). `TORCHFX_NO_SIMD=1` forces scalar.
+  Source: `sos_forward_cpu_simd_impl` in
+  [iir_cpu.cpp](src/torchfx/_csrc/cpu/iir_cpu.cpp).
 - [ ] **CPU runtime feature dispatch (function multiversioning)** — *small.* Ship AVX2/AVX-512
   CPU paths without `-march=native` breaking wheel portability (paired with the SIMD work above).
 

--- a/src/torchfx/_csrc/cpu/iir_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/iir_cpu.cpp
@@ -1,5 +1,9 @@
 #include <torch/torch.h>
 #include <omp.h>
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <tuple>
 #include <vector>
 
@@ -194,6 +198,124 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> biquad_forward_cpu(
   return biquad_forward_cpu_impl<double>(x_exec, b_exec, a1, a2, sx_exec, sy_exec);
 }
 
+// Cache-blocked cross-channel SIMD SOS cascade (Roadmap Epic 4.6 / #24).
+//
+// The DF1 SOS recurrence is serial in time and across sections but INDEPENDENT
+// across channels, with coefficients shared by all channels. The scalar kernel
+// parallelises channels over OpenMP threads; once C > cores each thread processes
+// several channels SERIALLY (the time the throughput goes linear in C).
+//
+// This path packs a group of W channels into SIMD lanes: it transposes a small
+// [W, B] tile into channel-contiguous [B, W] (kept in L1 — unlike the reverted F1
+// attempt that transposed the whole [C, T] and went memory-bound), runs the
+// recurrence with the per-time-step channel loop auto-vectorising (#pragma omp simd),
+// and transposes the output tile back. OpenMP runs over channel groups so cores AND
+// SIMD lanes are both used. Engaged only when C > num_threads (see the dispatcher).
+template <typename scalar_t>
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> sos_forward_cpu_simd_impl(
+    const torch::Tensor& x,       // [C, T]
+    const torch::Tensor& sos,     // [K, 6]
+    const torch::Tensor& state_x, // [K, C, 2]
+    const torch::Tensor& state_y) {
+
+  auto sx = state_x.clone();
+  auto sy = state_y.clone();
+
+  const int64_t K = sos.size(0);
+  const int64_t C = x.size(0);
+  const int64_t T = x.size(1);
+
+  auto sos_acc = sos.accessor<scalar_t, 2>();
+  std::vector<scalar_t> cb0(K), cb1(K), cb2(K), ca1(K), ca2(K);
+  for (int64_t s = 0; s < K; ++s) {
+    cb0[s] = sos_acc[s][0];
+    cb1[s] = sos_acc[s][1];
+    cb2[s] = sos_acc[s][2];
+    ca1[s] = sos_acc[s][4];
+    ca2[s] = sos_acc[s][5];
+  }
+
+  auto y = torch::empty_like(x);
+  const scalar_t* xp = x.data_ptr<scalar_t>();  // [C, T] contiguous
+  scalar_t* yp = y.data_ptr<scalar_t>();
+  auto sx_acc = sx.accessor<scalar_t, 3>();  // [K, C, 2]
+  auto sy_acc = sy.accessor<scalar_t, 3>();
+
+  // Group width = one SIMD vector (4 f32 in a 128-bit NEON/SSE register). Keeping it
+  // narrow maximises the number of channel groups, so OpenMP fills the cores even at
+  // moderate C (e.g. C=8 on 4 cores -> 2 groups -> 2 cores, not 1). The inner channel
+  // loop auto-vectorises to one vector op per section per time step.
+  constexpr int64_t W = 4;
+  constexpr int64_t B = 256;  // time block; the W*B tile stays in L1
+
+  #pragma omp parallel for schedule(static) if (C > W)
+  for (int64_t c0 = 0; c0 < C; c0 += W) {
+    const int64_t cw = std::min<int64_t>(W, C - c0);
+
+    // Per-group, channel-contiguous section state [K][W] (unused lanes stay 0).
+    std::vector<scalar_t> ssx0(K * W, 0), ssx1(K * W, 0), ssy0(K * W, 0), ssy1(K * W, 0);
+    for (int64_t s = 0; s < K; ++s) {
+      for (int64_t c = 0; c < cw; ++c) {
+        ssx0[s * W + c] = sx_acc[s][c0 + c][0];
+        ssx1[s * W + c] = sx_acc[s][c0 + c][1];
+        ssy0[s * W + c] = sy_acc[s][c0 + c][0];
+        ssy1[s * W + c] = sy_acc[s][c0 + c][1];
+      }
+    }
+
+    std::vector<scalar_t> tile(B * W);
+
+    for (int64_t bt = 0; bt < T; bt += B) {
+      const int64_t bb = std::min<int64_t>(B, T - bt);
+      if (cw < W) std::memset(tile.data(), 0, sizeof(scalar_t) * bb * W);
+
+      // Load + transpose [cw, bb] -> tile[bb][W] (channel-contiguous per time step).
+      for (int64_t c = 0; c < cw; ++c) {
+        const scalar_t* xrow = xp + (c0 + c) * T + bt;
+        for (int64_t n = 0; n < bb; ++n) tile[n * W + c] = xrow[n];
+      }
+
+      // Recurrence over the tile; the channel loop (constant W) auto-vectorises.
+      for (int64_t n = 0; n < bb; ++n) {
+        scalar_t* row = &tile[n * W];
+        for (int64_t s = 0; s < K; ++s) {
+          scalar_t* __restrict px0 = &ssx0[s * W];
+          scalar_t* __restrict px1 = &ssx1[s * W];
+          scalar_t* __restrict py0 = &ssy0[s * W];
+          scalar_t* __restrict py1 = &ssy1[s * W];
+          const scalar_t b0 = cb0[s], b1 = cb1[s], b2 = cb2[s], a1 = ca1[s], a2 = ca2[s];
+          #pragma omp simd
+          for (int64_t c = 0; c < W; ++c) {
+            const scalar_t yn = b0 * row[c] + b1 * px0[c] + b2 * px1[c] - a1 * py0[c] - a2 * py1[c];
+            px1[c] = px0[c];
+            px0[c] = row[c];
+            py1[c] = py0[c];
+            py0[c] = yn;
+            row[c] = yn;  // cascade into the next section / final output
+          }
+        }
+      }
+
+      // Transpose tile[bb][cw] -> y[c0..][bt..].
+      for (int64_t c = 0; c < cw; ++c) {
+        scalar_t* yrow = yp + (c0 + c) * T + bt;
+        for (int64_t n = 0; n < bb; ++n) yrow[n] = tile[n * W + c];
+      }
+    }
+
+    for (int64_t s = 0; s < K; ++s) {
+      for (int64_t c = 0; c < cw; ++c) {
+        sx_acc[s][c0 + c][0] = ssx0[s * W + c];
+        sx_acc[s][c0 + c][1] = ssx1[s * W + c];
+        sy_acc[s][c0 + c][0] = ssy0[s * W + c];
+        sy_acc[s][c0 + c][1] = ssy1[s * W + c];
+      }
+    }
+  }
+
+  return std::make_tuple(y, sx, sy);
+}
+
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> sos_forward_cpu(
     const torch::Tensor& x,         // [C, T]
     const torch::Tensor& sos,       // [K, 6]
@@ -211,9 +333,23 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> sos_forward_cpu(
   const auto sx_exec = state_x.to(exec_dtype).contiguous();
   const auto sy_exec = state_y.to(exec_dtype).contiguous();
 
+  // Cross-channel SIMD helps only once channels outnumber cores (each thread then
+  // runs several channels serially). Below that the scalar path is already optimal,
+  // and the tile transposes would be pure overhead. TORCHFX_NO_SIMD=1 forces scalar;
+  // TORCHFX_FORCE_SIMD=1 forces the SIMD path at any C (for testing/benchmarking).
+  const char* no_simd = std::getenv("TORCHFX_NO_SIMD");
+  const char* force_simd = std::getenv("TORCHFX_FORCE_SIMD");
+  const int64_t C = x_exec.size(0);
+  const bool use_simd =
+      (no_simd == nullptr || no_simd[0] != '1') &&
+      ((force_simd != nullptr && force_simd[0] == '1') ||
+       C > static_cast<int64_t>(omp_get_max_threads()));
+
   if (exec_dtype == torch::kFloat32) {
-    return sos_forward_cpu_impl<float>(x_exec, sos_exec, sx_exec, sy_exec);
+    return use_simd ? sos_forward_cpu_simd_impl<float>(x_exec, sos_exec, sx_exec, sy_exec)
+                    : sos_forward_cpu_impl<float>(x_exec, sos_exec, sx_exec, sy_exec);
   }
 
-  return sos_forward_cpu_impl<double>(x_exec, sos_exec, sx_exec, sy_exec);
+  return use_simd ? sos_forward_cpu_simd_impl<double>(x_exec, sos_exec, sx_exec, sy_exec)
+                  : sos_forward_cpu_impl<double>(x_exec, sos_exec, sx_exec, sy_exec);
 }

--- a/src/torchfx/_csrc/cpu/iir_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/iir_cpu.cpp
@@ -7,6 +7,16 @@
 #include <tuple>
 #include <vector>
 
+// MSVC's default `/openmp` (2.0) rejects `#pragma omp simd` with a hard error (C7660,
+// it needs `/openmp:experimental`). Emit the SIMD hint only on GCC/Clang, where it is
+// validated and works with or without `-fopenmp`; MSVC still auto-vectorises the small
+// fixed-trip channel loop (its operands are `__restrict`) under `/O2`.
+#ifdef _MSC_VER
+#define TORCHFX_OMP_SIMD
+#else
+#define TORCHFX_OMP_SIMD _Pragma("omp simd")
+#endif
+
 // CPU implementation of biquad Direct Form 1.
 // Vectorized across channels, sequential across time.
 // This is significantly faster than the Python for-loop.
@@ -284,7 +294,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> sos_forward_cpu_simd_imp
           scalar_t* __restrict py0 = &ssy0[s * W];
           scalar_t* __restrict py1 = &ssy1[s * W];
           const scalar_t b0 = cb0[s], b1 = cb1[s], b2 = cb2[s], a1 = ca1[s], a2 = ca2[s];
-          #pragma omp simd
+          TORCHFX_OMP_SIMD
           for (int64_t c = 0; c < W; ++c) {
             const scalar_t yn = b0 * row[c] + b1 * px0[c] + b2 * px1[c] - a1 * py0[c] - a2 * py1[c];
             px1[c] = px0[c];

--- a/src/torchfx/_csrc/cpu/iir_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/iir_cpu.cpp
@@ -340,10 +340,18 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> sos_forward_cpu(
   const char* no_simd = std::getenv("TORCHFX_NO_SIMD");
   const char* force_simd = std::getenv("TORCHFX_FORCE_SIMD");
   const int64_t C = x_exec.size(0);
+  // omp_get_max_threads() is a runtime call; guard it so the extension still links
+  // where OpenMP is unavailable (e.g. MSVC/cibuildwheel, which doesn't link the
+  // runtime — only the #pragma omp directives, which it harmlessly ignores). Without
+  // OpenMP the SIMD path still vectorises, just single-threaded, so gate on 1.
+#ifdef _OPENMP
+  const int64_t nthreads = static_cast<int64_t>(omp_get_max_threads());
+#else
+  const int64_t nthreads = 1;
+#endif
   const bool use_simd =
       (no_simd == nullptr || no_simd[0] != '1') &&
-      ((force_simd != nullptr && force_simd[0] == '1') ||
-       C > static_cast<int64_t>(omp_get_max_threads()));
+      ((force_simd != nullptr && force_simd[0] == '1') || C > nthreads);
 
   if (exec_dtype == torch::kFloat32) {
     return use_simd ? sos_forward_cpu_simd_impl<float>(x_exec, sos_exec, sx_exec, sy_exec)

--- a/tests/test_simd_sos.py
+++ b/tests/test_simd_sos.py
@@ -1,0 +1,91 @@
+"""Cross-channel SIMD CPU SOS path equivalence (issue #24).
+
+``TORCHFX_FORCE_SIMD=1`` engages the cache-blocked cross-channel SIMD kernel at any
+channel count; ``TORCHFX_NO_SIMD=1`` forces the scalar path. This checks the SIMD path
+reproduces the scalar kernel and ``scipy.signal.sosfilt`` across channel counts
+(including partial SIMD groups), section counts, and dtypes, and that it carries
+streaming state correctly across chunks.
+
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+import torch
+from scipy.signal import butter, sosfilt
+
+
+def _run(x, sos, simd: bool):
+    from torchfx._ops import parallel_iir_forward
+
+    keep = {k: os.environ.get(k) for k in ("TORCHFX_NO_SIMD", "TORCHFX_FORCE_SIMD")}
+    os.environ.pop("TORCHFX_NO_SIMD", None)
+    os.environ.pop("TORCHFX_FORCE_SIMD", None)
+    os.environ["TORCHFX_FORCE_SIMD" if simd else "TORCHFX_NO_SIMD"] = "1"
+    try:
+        y, sx, sy = parallel_iir_forward(x, sos, None, None, sos_cpu=sos)
+    finally:
+        for k, v in keep.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+    return y, sx, sy
+
+
+def _cascade(k: int) -> np.ndarray:
+    return np.concatenate([butter(2, c, output="sos") for c in np.linspace(0.1, 0.4, k)], axis=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("k", [1, 3, 6])
+@pytest.mark.parametrize("c", [1, 2, 3, 4, 5, 7, 8, 9, 16, 17])
+def test_simd_matches_scalar_and_scipy(dtype, k, c):
+    t = 2000
+    sos_np = _cascade(k)
+    g = torch.Generator().manual_seed(k * 100 + c)
+    x = torch.randn(c, t, generator=g, dtype=dtype)
+    sos = torch.tensor(sos_np, dtype=dtype)
+
+    scalar, _, _ = _run(x, sos, simd=False)
+    simd, _, _ = _run(x, sos, simd=True)
+
+    # Same math, same order -> tight; both within a float bound of the scipy reference.
+    tol = {"rtol": 1e-5, "atol": 1e-6} if dtype == torch.float32 else {"rtol": 1e-12, "atol": 1e-13}
+    torch.testing.assert_close(simd, scalar, **tol)
+    ref = torch.tensor(sosfilt(sos_np, x.double().numpy(), axis=-1), dtype=dtype)
+    stol = {"rtol": 2e-3, "atol": 2e-4} if dtype == torch.float32 else {"rtol": 1e-9, "atol": 1e-10}
+    torch.testing.assert_close(simd.cpu(), ref, **stol)
+
+
+def test_simd_streaming_state_continuity():
+    """Chunked streaming through the SIMD path == whole-signal processing."""
+    from torchfx._ops import parallel_iir_forward
+
+    c, k, t = 16, 3, 4096  # C > typical core count so the SIMD path is exercised
+    sos_np = _cascade(k)
+    g = torch.Generator().manual_seed(0)
+    x = torch.randn(c, t, dtype=torch.float64, generator=g)
+    sos = torch.tensor(sos_np, dtype=torch.float64)
+
+    whole, _, _ = _run(x, sos, simd=True)
+
+    prev = os.environ.get("TORCHFX_FORCE_SIMD")
+    os.environ["TORCHFX_FORCE_SIMD"] = "1"
+    try:
+        sx = sy = None
+        outs = []
+        for chunk in x.split(700, dim=1):
+            y, sx, sy = parallel_iir_forward(chunk, sos, sx, sy, sos_cpu=sos)
+            outs.append(y)
+        streamed = torch.cat(outs, dim=1)
+    finally:
+        if prev is None:
+            os.environ.pop("TORCHFX_FORCE_SIMD", None)
+        else:
+            os.environ["TORCHFX_FORCE_SIMD"] = prev
+
+    torch.testing.assert_close(streamed, whole, rtol=1e-12, atol=1e-13)


### PR DESCRIPTION
## What
A cache-blocked cross-channel SIMD path for the CPU SOS cascade. When channels outnumber CPU cores, the scalar per-channel kernel runs several channels serially on each core (throughput goes linear in `C`). The new path packs a SIMD vector of channels instead.

## Why (#24)
The scalar OpenMP-over-channels kernel is optimal for `C ≤ cores` but goes linear beyond it. A first attempt (F1, in 0.6.0) that transposed the whole `[C,T]` to `[T,C]` **regressed 4–8× on a 10-core desktop** — the transpose moved as much memory as the streaming-light recurrence computes. This fixes that.

## How
- `sos_forward_cpu_simd_impl`: transposes only small `[W=4, B=256]` tiles to channel-contiguous `[B,W]` that **stay in L1**; the per-time-step channel loop auto-vectorises (NEON/SSE/AVX); transposes back. OpenMP over the narrow groups fills **cores and SIMD lanes** even at moderate `C`.
- **Gated to `C > omp_get_max_threads()`** so `C ≤ cores` keeps the optimal scalar path (the regime that made F1 a regression).
- `TORCHFX_NO_SIMD=1` forces scalar; `TORCHFX_FORCE_SIMD=1` forces SIMD (testing/bench).

## Results — 4-section SOS, float32, 5 s @ 48 kHz
| C | Pi 5 (Cortex-A76 ×4) | x86 (12 cores) |
|---|---|---|
| 8  | **1.81×** | scalar (≤ cores) |
| 16 | **2.60×** | **1.27×** |
| 32 | **2.60×** | **2.39×** |

No regression for `C ≤ cores` (scalar path retained); win on **both** the Pi (edge target) and the desktop for `C > cores`.

## Correctness
- SIMD == scalar == `scipy.signal.sosfilt` across `C` (incl. partial groups 7/9/17), `K ∈ {1,3,6}`, f32/f64.
- New `tests/test_simd_sos.py` (61 cases incl. chunked streaming-state continuity).
- Full suite **1194 passed**; **1133 passed with `TORCHFX_FORCE_SIMD=1`** (every SOS call routed through SIMD).
- Validated on a Raspberry Pi 5 (ARM/NEON) and x86.

Closes #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)