### PR TITLE
✨ Look-ahead brick-wall Limiter (#31)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`Limiter` — look-ahead brick-wall peak limiter.** Guarantees `|y| <= threshold` (a
+  true brick wall) while staying transparent: a short `lookahead` reduces the gain
+  *before* a peak (a vectorised forward max-pool computes the look-ahead window), the gain
+  is attack/release-smoothed toward that target, and a per-sample clamp enforces the
+  ceiling exactly. Unlike `Compressor(ratio=inf)` — a zero-look-ahead limiter that can
+  overshoot a single sample before its gain reacts — this never exceeds the ceiling.
+  Native `limiter_forward` kernel (CPU + CUDA, FP32/FP64). Usage:
+  `wave | Limiter(threshold=-1.0, lookahead=0.005)`. (Resolves #31.)
 - **`Expander` / `Gate` dynamics effects.** A downward expander — the mirror of the
   compressor, attenuating *below* the threshold — with `ratio`/`knee`/`attack`/`release`,
   an optional `floor` (range), and peak or RMS detection. `Gate` is the infinite-ratio

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,8 @@ Python_add_library(torchfx_ext MODULE WITH_SOABI
   "${CSRC_DIR}/cpu/iir_cpu.cpp"
   "${CSRC_DIR}/cpu/delay_cpu.cpp"
   "${CSRC_DIR}/cpu/compressor_cpu.cpp"
-  "${CSRC_DIR}/cpu/expander_cpu.cpp")
+  "${CSRC_DIR}/cpu/expander_cpu.cpp"
+  "${CSRC_DIR}/cpu/limiter_cpu.cpp")
 
 if(TORCHFX_USE_CUDA)
   target_sources(torchfx_ext PRIVATE
@@ -92,7 +93,8 @@ if(TORCHFX_USE_CUDA)
     "${CSRC_DIR}/cuda/biquad_forward.cu"
     "${CSRC_DIR}/cuda/delay_forward.cu"
     "${CSRC_DIR}/cuda/compressor_forward.cu"
-    "${CSRC_DIR}/cuda/expander_forward.cu")
+    "${CSRC_DIR}/cuda/expander_forward.cu"
+    "${CSRC_DIR}/cuda/limiter_forward.cu")
   target_compile_definitions(torchfx_ext PRIVATE WITH_CUDA)
   set_target_properties(torchfx_ext PROPERTIES CUDA_ARCHITECTURES "${TORCHFX_CUDA_ARCHS}")
 endif()

--- a/docs/source/guides/developer/roadmap.md
+++ b/docs/source/guides/developer/roadmap.md
@@ -690,7 +690,10 @@ Each item lists its difficulty and expected impact; none block a release.
 
 - [x] Compressor (threshold, ratio, attack, release, knee) — `Compressor` (#30), native
   per-channel C++/CUDA detector, peak/RMS, soft knee, `ratio=inf` limiter mode.
-- [ ] Limiter (brickwall, true peak, look-ahead)
+- [x] Limiter (brickwall, look-ahead) — `Limiter` (#31): look-ahead windowed peak
+  (vectorised max-pool) + attack/release gain smoothing + a per-sample clamp that
+  guarantees `|y| <= threshold`; native CPU + CUDA. (True-peak / oversampled detection
+  is a possible follow-up.)
 - [x] Expander / Gate — `Expander` (downward expansion below threshold) + `Gate`
   (infinite-ratio convenience) (#32), mirroring the compressor detector with an
   optional `floor` (range); native CPU + CUDA.

--- a/src/torchfx/_csrc/binding.cpp
+++ b/src/torchfx/_csrc/binding.cpp
@@ -5,6 +5,7 @@
 #include "torchfx/delay_kernel.h"
 #include "torchfx/compressor_kernel.h"
 #include "torchfx/expander_kernel.h"
+#include "torchfx/limiter_kernel.h"
 #endif
 
 // CPU implementation declarations
@@ -49,6 +50,13 @@ torch::Tensor expander_forward_cpu(
     double release_coeff,
     double rms_coeff,
     int detector);
+
+torch::Tensor limiter_forward_cpu(
+    const torch::Tensor& x,
+    const torch::Tensor& peak_env,
+    double threshold_lin,
+    double attack_coeff,
+    double release_coeff);
 
 // Dispatch: select CUDA or CPU implementation based on tensor device.
 // `threshold` is the sequential-vs-parallel-scan boundary used by the CUDA path
@@ -162,6 +170,24 @@ torch::Tensor expander_forward(
                               attack_coeff, release_coeff, rms_coeff, detector);
 }
 
+// Look-ahead brick-wall limiter dispatch. `peak_env` is the precomputed look-ahead
+// windowed peak of |x|; `threshold_lin` is the linear ceiling.
+torch::Tensor limiter_forward(
+    const torch::Tensor& x,
+    const torch::Tensor& peak_env,
+    double threshold_lin,
+    double attack_coeff,
+    double release_coeff) {
+#ifdef WITH_CUDA
+  if (x.is_cuda()) {
+    return torchfx::limiter_forward_cuda(x, peak_env, threshold_lin, attack_coeff, release_coeff);
+  }
+#else
+  TORCH_CHECK(!x.is_cuda(), "CUDA extension not compiled; move tensors to CPU");
+#endif
+  return limiter_forward_cpu(x, peak_env, threshold_lin, attack_coeff, release_coeff);
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("biquad_forward", &biquad_forward,
         "Biquad filter forward (CUDA/CPU)",
@@ -185,4 +211,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         py::arg("x"), py::arg("threshold"), py::arg("slope"), py::arg("knee"),
         py::arg("floor_db"), py::arg("attack_coeff"), py::arg("release_coeff"),
         py::arg("rms_coeff"), py::arg("detector"));
+  m.def("limiter_forward", &limiter_forward,
+        "Look-ahead brick-wall limiter forward (CUDA/CPU)",
+        py::arg("x"), py::arg("peak_env"), py::arg("threshold_lin"),
+        py::arg("attack_coeff"), py::arg("release_coeff"));
 }

--- a/src/torchfx/_csrc/cpu/limiter_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/limiter_cpu.cpp
@@ -1,0 +1,87 @@
+#include <torch/torch.h>
+#include <algorithm>
+#include <cmath>
+
+// CPU look-ahead brick-wall limiter (gain stage). The look-ahead windowed peak is
+// precomputed; this runs the sequential gain recurrence, one channel per OpenMP thread.
+// See include/torchfx/limiter_kernel.h for the per-sample math.
+
+#if defined(_MSC_VER)
+#define TORCHFX_RESTRICT __restrict
+#else
+#define TORCHFX_RESTRICT __restrict__
+#endif
+
+template <typename scalar_t>
+static void limiter_loop(
+    const scalar_t* TORCHFX_RESTRICT in_ptr,
+    const scalar_t* TORCHFX_RESTRICT peak_ptr,
+    scalar_t* TORCHFX_RESTRICT out_ptr,
+    int64_t C,
+    int64_t T,
+    scalar_t threshold_lin,
+    scalar_t attack_coeff,
+    scalar_t release_coeff) {
+
+  const scalar_t eps = static_cast<scalar_t>(1e-12);
+  const scalar_t one = static_cast<scalar_t>(1);
+
+  #pragma omp parallel for schedule(static) if(C > 1)
+  for (int64_t c = 0; c < C; ++c) {
+    const scalar_t* in_c = in_ptr + c * T;
+    const scalar_t* peak_c = peak_ptr + c * T;
+    scalar_t* out_c = out_ptr + c * T;
+
+    scalar_t g = one;
+    for (int64_t n = 0; n < T; ++n) {
+      const scalar_t gr = std::min(one, threshold_lin / std::max(peak_c[n], eps));
+      if (gr < g) {
+        g = attack_coeff * g + (one - attack_coeff) * gr;
+      } else {
+        g = release_coeff * g + (one - release_coeff) * gr;
+      }
+      const scalar_t clamp = threshold_lin / std::max(std::abs(in_c[n]), eps);
+      const scalar_t g_out = std::min(g, clamp);
+      out_c[n] = g_out * in_c[n];
+    }
+  }
+}
+
+torch::Tensor limiter_forward_cpu(
+    const torch::Tensor& x,
+    const torch::Tensor& peak_env,
+    double threshold_lin,
+    double attack_coeff,
+    double release_coeff) {
+
+  TORCH_CHECK(!x.is_cuda(), "limiter_forward_cpu: input must be on CPU");
+  TORCH_CHECK(x.sizes() == peak_env.sizes(), "limiter_forward_cpu: x and peak_env must match");
+
+  auto x_cont = x.contiguous();
+  auto peak_cont = peak_env.contiguous();
+  const int orig_dim = x_cont.dim();
+  if (orig_dim == 1) {
+    x_cont = x_cont.unsqueeze(0);
+    peak_cont = peak_cont.unsqueeze(0);
+  }
+
+  const int64_t C = x_cont.size(0);
+  const int64_t T = x_cont.size(1);
+  auto output = torch::empty_like(x_cont);
+
+  if (x_cont.dtype() == torch::kFloat32) {
+    limiter_loop<float>(
+        x_cont.data_ptr<float>(), peak_cont.data_ptr<float>(), output.data_ptr<float>(),
+        C, T, static_cast<float>(threshold_lin), static_cast<float>(attack_coeff),
+        static_cast<float>(release_coeff));
+  } else {
+    limiter_loop<double>(
+        x_cont.data_ptr<double>(), peak_cont.data_ptr<double>(), output.data_ptr<double>(),
+        C, T, threshold_lin, attack_coeff, release_coeff);
+  }
+
+  if (orig_dim == 1) {
+    return output.squeeze(0);
+  }
+  return output;
+}

--- a/src/torchfx/_csrc/cuda/limiter_forward.cu
+++ b/src/torchfx/_csrc/cuda/limiter_forward.cu
@@ -1,0 +1,90 @@
+#include <torch/torch.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <c10/cuda/CUDAStream.h>
+#include "torchfx/limiter_kernel.h"
+
+// Look-ahead brick-wall limiter (gain stage). The look-ahead windowed peak is precomputed;
+// this runs the sequential gain recurrence, one thread per channel. Templated on scalar_t
+// so a float32 input runs natively in FP32. See limiter_kernel.h for the math.
+
+namespace torchfx {
+
+template <typename scalar_t>
+__global__ void limiter_kernel(
+    const scalar_t* __restrict__ input,
+    const scalar_t* __restrict__ peak_env,
+    scalar_t* __restrict__ output,
+    scalar_t threshold_lin,
+    scalar_t attack_coeff,
+    scalar_t release_coeff,
+    int C,
+    int T) {
+
+  const int channel = blockIdx.x * blockDim.x + threadIdx.x;
+  if (channel >= C) return;
+
+  const scalar_t* in_c = input + static_cast<int64_t>(channel) * T;
+  const scalar_t* peak_c = peak_env + static_cast<int64_t>(channel) * T;
+  scalar_t* out_c = output + static_cast<int64_t>(channel) * T;
+
+  const scalar_t eps = static_cast<scalar_t>(1e-12);
+  const scalar_t one = static_cast<scalar_t>(1);
+
+  scalar_t g = one;
+  for (int n = 0; n < T; ++n) {
+    const scalar_t gr = fmin(one, threshold_lin / fmax(peak_c[n], eps));
+    if (gr < g) {
+      g = attack_coeff * g + (one - attack_coeff) * gr;
+    } else {
+      g = release_coeff * g + (one - release_coeff) * gr;
+    }
+    const scalar_t clamp = threshold_lin / fmax(fabs(in_c[n]), eps);
+    const scalar_t g_out = fmin(g, clamp);
+    out_c[n] = g_out * in_c[n];
+  }
+}
+
+torch::Tensor limiter_forward_cuda(
+    const torch::Tensor& x,
+    const torch::Tensor& peak_env,
+    double threshold_lin,
+    double attack_coeff,
+    double release_coeff) {
+
+  TORCH_CHECK(x.is_cuda(), "limiter_forward_cuda: input must be on CUDA");
+  TORCH_CHECK(x.sizes() == peak_env.sizes(), "limiter_forward_cuda: x and peak_env must match");
+
+  auto x_cont = x.contiguous();
+  auto peak_cont = peak_env.contiguous();
+  int64_t C, T;
+  if (x_cont.dim() == 1) {
+    C = 1;
+    T = x_cont.size(0);
+    x_cont = x_cont.unsqueeze(0);
+    peak_cont = peak_cont.unsqueeze(0);
+  } else {
+    C = x_cont.size(0);
+    T = x_cont.size(1);
+  }
+
+  auto output = torch::empty_like(x_cont);
+
+  const int threads = 128;
+  const int blocks = (static_cast<int>(C) + threads - 1) / threads;
+  const auto stream = c10::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_FLOATING_TYPES(x_cont.scalar_type(), "limiter_forward_cuda", [&] {
+    limiter_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+        x_cont.data_ptr<scalar_t>(), peak_cont.data_ptr<scalar_t>(), output.data_ptr<scalar_t>(),
+        static_cast<scalar_t>(threshold_lin), static_cast<scalar_t>(attack_coeff),
+        static_cast<scalar_t>(release_coeff), static_cast<int>(C), static_cast<int>(T));
+  });
+
+  if (x.dim() == 1) {
+    return output.squeeze(0);
+  }
+  return output;
+}
+
+}  // namespace torchfx

--- a/src/torchfx/_csrc/include/torchfx/limiter_kernel.h
+++ b/src/torchfx/_csrc/include/torchfx/limiter_kernel.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <torch/types.h>
+
+namespace torchfx {
+
+// Look-ahead brick-wall peak limiter (gain stage).
+//
+// The look-ahead windowed peak `peak_env[n] = max(|x[n .. n+L]|)` is precomputed by the
+// Python layer (a vectorised forward max-pool), so this kernel only runs the sequential
+// gain recurrence — one channel per thread, over time n:
+//   gr    = min(1, threshold_lin / max(peak_env[n], eps))   (windowed target; look-ahead)
+//   g     = gr < g ? a_A*g + (1-a_A)*gr                       (attack: smooth ramp down)
+//                  : a_R*g + (1-a_R)*gr                        (release: smooth ramp up)
+//   g_out = min(g, threshold_lin / max(|x[n]|, eps))          (per-sample brick-wall clamp)
+//   y[n]  = g_out * x[n]
+//
+// The windowed target makes `g` start ramping down *before* a peak arrives (no transient
+// overshoot, no click), while the per-sample clamp guarantees |y[n]| <= threshold_lin — a
+// true brick wall — even though `g` itself is smoothed.
+torch::Tensor limiter_forward_cuda(
+    const torch::Tensor& x,
+    const torch::Tensor& peak_env,
+    double threshold_lin,
+    double attack_coeff,
+    double release_coeff);
+
+}  // namespace torchfx

--- a/src/torchfx/_ops.py
+++ b/src/torchfx/_ops.py
@@ -389,3 +389,60 @@ def expander_forward(
     if len(original_shape) == 2:
         return result_2d
     return result_2d.reshape(original_shape)
+
+
+def limiter_forward(
+    x: Tensor,
+    threshold_lin: float,
+    attack_coeff: float,
+    release_coeff: float,
+    lookahead_samples: int,
+) -> Tensor:
+    """Dispatch the look-ahead brick-wall limiter to the native kernel (CUDA or CPU).
+
+    The look-ahead windowed peak ``peak_env[n] = max(|x[n .. n+L]|)`` is computed here
+    with a vectorised forward max-pool (so the gain is reduced *before* a peak arrives);
+    the native kernel then runs only the sequential gain recurrence (attack/release
+    smoothing plus a per-sample brick-wall clamp). ``threshold_lin`` is the linear
+    ceiling, ``lookahead_samples`` is ``L``. Returns the processed tensor with the input
+    shape and dtype preserved.
+
+    """
+    if x.ndim < 1:
+        raise ValueError("Input tensor must have at least 1 dimension.")
+    if not x.is_floating_point():
+        raise TypeError("Input tensor must use a floating-point dtype.")
+
+    original_shape = x.shape
+    if x.ndim == 1:
+        x_2d = x.unsqueeze(0)
+    elif x.ndim == 2:
+        x_2d = x
+    else:
+        x_2d = x.reshape(-1, x.size(-1))
+
+    native_dtype = torch.float64 if x_2d.dtype == torch.float64 else torch.float32
+    x_native = x_2d if x_2d.dtype == native_dtype else x_2d.to(dtype=native_dtype)
+
+    # Forward look-ahead windowed peak: max of |x| over [n, n+L]. Zero-pad the tail so the
+    # window shrinks gracefully at the end (zeros never raise the max).
+    abs_x = x_native.abs()
+    lookahead = max(0, int(lookahead_samples))
+    if lookahead > 0:
+        padded = torch.nn.functional.pad(abs_x, (0, lookahead))
+        peak_env = torch.nn.functional.max_pool1d(
+            padded.unsqueeze(0), kernel_size=lookahead + 1, stride=1
+        ).squeeze(0)
+    else:
+        peak_env = abs_x
+
+    result_native: Tensor = _ext.limiter_forward(
+        x_native, peak_env.contiguous(), threshold_lin, attack_coeff, release_coeff
+    )
+    result_2d = result_native if result_native.dtype == x.dtype else result_native.to(dtype=x.dtype)
+
+    if len(original_shape) == 1:
+        return result_2d.squeeze(0)
+    if len(original_shape) == 2:
+        return result_2d
+    return result_2d.reshape(original_shape)

--- a/src/torchfx/effect.py
+++ b/src/torchfx/effect.py
@@ -2003,3 +2003,143 @@ class Gate(Expander):
             detector=detector,
             fs=fs,
         )
+
+
+class Limiter(FX):
+    r"""Look-ahead brick-wall peak limiter.
+
+    Guarantees the output magnitude never exceeds ``threshold`` (a true brick wall) while
+    staying transparent: a short ``lookahead`` lets the gain reduce *before* a peak
+    arrives, so there is no transient overshoot and none of the distortion an
+    instantaneous gain change would cause. The gain then recovers over ``release``.
+
+    The look-ahead windowed peak of ``|x|`` is computed with a vectorised max-pool, and the
+    sequential gain recurrence runs in a native C++/CUDA kernel (one channel per thread).
+
+    Parameters
+    ----------
+    threshold : float, default=-1.0
+        Output ceiling in **dBFS**. The output magnitude never exceeds this.
+    lookahead : float, default=0.005
+        Look-ahead time in **seconds**: the gain is reduced over this window ahead of a
+        peak so the limiter never overshoots. ``0`` is a zero-look-ahead limiter.
+    release : float, default=0.05
+        Release time in **seconds** — how fast the gain recovers after a peak. ``0`` is
+        instantaneous.
+    fs : int or None, default=None
+        Sampling rate in Hz. May be left ``None`` and supplied lazily by a ``Wave``
+        pipeline (``wave | limiter``).
+
+    Returns
+    -------
+    Tensor
+        The limited waveform, same shape and dtype as the input, with
+        ``|y| <= 10**(threshold/20)`` everywhere.
+
+    Raises
+    ------
+    ValueError
+        If ``lookahead`` or ``release`` is negative, ``fs`` is non-positive, or ``forward``
+        is called before ``fs`` is known.
+
+    See Also
+    --------
+    Compressor : ``Compressor(ratio=inf)`` is a zero-look-ahead feed-forward limiter that
+        can overshoot on a single sample before its gain reacts; ``Limiter`` cannot.
+
+    Notes
+    -----
+    For each sample the applied gain is
+
+    .. math::
+
+        g[n] = \min\!\Big(\tfrac{T_\text{lin}}{\max(p[n], \epsilon)},\ a_R\,g[n-1] + (1-a_R)\Big),
+        \qquad p[n] = \max_{0 \le k \le L} |x[n+k]|
+
+    with linear ceiling :math:`T_\text{lin} = 10^{\text{threshold}/20}`, release coefficient
+    :math:`a_R = e^{-1/(\text{release}\cdot f_s)}`, and look-ahead :math:`L`. Since
+    :math:`|x[n]| \le p[n]`, the output :math:`y[n] = g[n]\,x[n]` satisfies
+    :math:`|y[n]| \le T_\text{lin}` — a guaranteed brick wall.
+
+    This is a **peak** (not true-peak / oversampled) limiter, so inter-sample peaks may
+    slightly exceed the ceiling after conversion to analog (true-peak limiting is a possible
+    follow-up). The output is time-aligned with the input (no net latency). Ballistics state
+    is reset per ``forward`` call (not state-continuous across streaming chunks).
+
+    Examples
+    --------
+    Brick-wall a signal that exceeds full scale to a -1 dBFS ceiling:
+
+    >>> import torch
+    >>> from torchfx.effect import Limiter
+    >>> x = torch.randn(2, 48000) * 3.0  # well over +/-1
+    >>> lim = Limiter(threshold=-1.0, lookahead=0.005, release=0.05, fs=48000)
+    >>> y = lim(x)
+    >>> bool(y.abs().max() <= 10 ** (-1.0 / 20) + 1e-4)
+    True
+
+    """
+
+    def __init__(
+        self,
+        threshold: float = -1.0,
+        lookahead: float = 0.005,
+        release: float = 0.05,
+        fs: int | None = None,
+    ) -> None:
+        super().__init__()
+        if lookahead < 0:
+            raise ValueError(f"lookahead must be non-negative (seconds), got {lookahead}.")
+        if release < 0:
+            raise ValueError(f"release must be non-negative (seconds), got {release}.")
+        if fs is not None and fs <= 0:
+            raise ValueError(f"Sample rate (fs) must be positive, got {fs}.")
+
+        self.threshold = float(threshold)
+        self.lookahead = float(lookahead)
+        self.release = float(release)
+        self.fs = fs
+
+        self._thr_lin = 10.0 ** (self.threshold / 20.0)
+        self._attack_coeff = 0.0
+        self._release_coeff = 0.0
+        self._lookahead_samples = 0
+        self._last_fs: int | None = None
+        self._needs_calculation = True
+
+    def _compute_coeffs(self) -> None:
+        """Derive ceiling, attack/release coefficients and look-ahead samples from
+        ``fs``."""
+        assert self.fs is not None
+        fs = self.fs
+        self._thr_lin = 10.0 ** (self.threshold / 20.0)
+        # Ramp the gain down over the look-ahead window so it is already low when the peak
+        # arrives (the per-sample clamp guarantees the brick wall regardless).
+        self._attack_coeff = 0.0 if self.lookahead == 0 else math.exp(-1.0 / (self.lookahead * fs))
+        self._release_coeff = 0.0 if self.release == 0 else math.exp(-1.0 / (self.release * fs))
+        self._lookahead_samples = int(round(self.lookahead * fs))
+        self._last_fs = fs
+        self._needs_calculation = False
+
+    @override
+    @torch.no_grad()
+    def forward(self, waveform: Tensor) -> Tensor:
+        if self._needs_calculation or self._last_fs != self.fs:
+            if self.fs is None:
+                raise ValueError(
+                    "Sample rate (fs) is required for the limiter. Use it in a "
+                    "Wave pipeline (wave | limiter) or pass fs at construction."
+                )
+            if self.fs <= 0:
+                raise ValueError("Sample rate (fs) must be positive.")
+            self._compute_coeffs()
+
+        from torchfx._ops import limiter_forward
+
+        return limiter_forward(
+            waveform,
+            self._thr_lin,
+            self._attack_coeff,
+            self._release_coeff,
+            self._lookahead_samples,
+        )

--- a/tests/test_limiter.py
+++ b/tests/test_limiter.py
@@ -1,0 +1,159 @@
+"""Tests for the look-ahead brick-wall Limiter (issue #31)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from torchfx.effect import Limiter
+
+FS = 48000
+
+
+def _thr_lin(db: float) -> float:
+    return 10 ** (db / 20)
+
+
+# --------------------------------------------------------------------------- #
+# Brick-wall guarantee: |y| never exceeds the ceiling
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("thr_db", [-1.0, -6.0, -12.0])
+@pytest.mark.parametrize("scale", [0.5, 1.0, 3.0, 10.0])
+def test_brickwall_never_exceeds_threshold(thr_db, scale):
+    lim = Limiter(threshold=thr_db, lookahead=0.005, release=0.05, fs=FS)
+    gen = torch.Generator().manual_seed(0)
+    x = torch.randn(2, 24000, generator=gen, dtype=torch.float64) * scale
+    y = lim(x)
+    assert y.abs().max().item() <= _thr_lin(thr_db) + 1e-9
+
+
+def test_brickwall_on_transients():
+    lim = Limiter(threshold=-6.0, lookahead=0.003, release=0.02, fs=FS)
+    x = torch.full((1, 10000), 0.2, dtype=torch.float64)
+    x[0, 5000] = 8.0  # single-sample spike far over full scale
+    x[0, 2000:2100] = 3.0  # a loud burst
+    y = lim(x)
+    assert y.abs().max().item() <= _thr_lin(-6.0) + 1e-9
+
+
+def test_brickwall_on_sine_over_full_scale():
+    lim = Limiter(threshold=-1.0, lookahead=0.005, release=0.05, fs=FS)
+    t = torch.arange(48000, dtype=torch.float64) / FS
+    x = (3.0 * torch.sin(2 * torch.pi * 220 * t)).unsqueeze(0)
+    y = lim(x)
+    assert y.abs().max().item() <= _thr_lin(-1.0) + 1e-9
+
+
+def test_lookahead_zero_still_brickwall():
+    lim = Limiter(threshold=-3.0, lookahead=0.0, release=0.05, fs=FS)
+    gen = torch.Generator().manual_seed(2)
+    x = torch.randn(1, 8000, generator=gen, dtype=torch.float64) * 2.0
+    y = lim(x)
+    assert y.abs().max().item() <= _thr_lin(-3.0) + 1e-9
+
+
+# --------------------------------------------------------------------------- #
+# Transparency + look-ahead behaviour
+# --------------------------------------------------------------------------- #
+def test_below_threshold_passes_through():
+    lim = Limiter(threshold=-1.0, lookahead=0.005, release=0.05, fs=FS)
+    gen = torch.Generator().manual_seed(3)
+    x = torch.randn(1, 8000, generator=gen, dtype=torch.float64) * 0.1  # peaks well below ceiling
+    assert x.abs().max().item() < _thr_lin(-1.0)
+    torch.testing.assert_close(lim(x), x, rtol=1e-9, atol=1e-12)
+
+
+def test_lookahead_reduces_gain_before_peak():
+    L = round(0.005 * FS)  # 240
+    spike_at = 2000
+    base = 0.3  # below the -6 dB ceiling (~0.501)
+    x = torch.full((1, 4000), base, dtype=torch.float64)
+    x[0, spike_at] = 5.0
+    y_la = Limiter(threshold=-6.0, lookahead=0.005, release=0.05, fs=FS)(x)
+    y_no = Limiter(threshold=-6.0, lookahead=0.0, release=0.05, fs=FS)(x)
+    # With look-ahead the gain is already pulling down within the window before the spike;
+    # without it the pre-spike samples (below threshold) are untouched.
+    assert y_la[0, spike_at - L // 2].abs().item() < 0.9 * base
+    assert y_no[0, spike_at - L // 2].abs().item() == pytest.approx(base, rel=1e-9)
+
+
+def test_release_recovers_after_peak():
+    lim = Limiter(threshold=-6.0, lookahead=0.002, release=0.03, fs=FS)
+    loud = torch.full((1, 2000), 4.0, dtype=torch.float64)
+    quiet = torch.full((1, 16000), 0.2, dtype=torch.float64)  # below ceiling
+    x = torch.cat([loud, quiet], dim=1)
+    y = lim(x)
+    g_tail = y[0, 2000:].abs() / x[0, 2000:].abs()
+    assert g_tail[0].item() < 0.9  # still attenuated right after the loud part
+    assert g_tail[-1].item() == pytest.approx(1.0, abs=1e-3)  # recovered (one-pole asymptote)
+
+
+# --------------------------------------------------------------------------- #
+# Shapes, dtypes, channels
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("shape", [(4096,), (2, 4096), (3, 2, 4096)])
+def test_shapes_preserved(shape):
+    lim = Limiter(threshold=-1.0, fs=FS)
+    x = torch.randn(*shape, dtype=torch.float64) * 2.0
+    y = lim(x)
+    assert y.shape == x.shape
+    assert y.abs().max().item() <= _thr_lin(-1.0) + 1e-9
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_dtype_preserved_and_brickwall(dtype):
+    lim = Limiter(threshold=-2.0, fs=FS)
+    x = torch.randn(2, 8000, dtype=dtype) * 2.0
+    y = lim(x)
+    assert y.dtype == dtype
+    eps = 1e-5 if dtype == torch.float32 else 1e-9
+    assert y.abs().max().item() <= _thr_lin(-2.0) + eps
+
+
+def test_identical_channels_identical_output():
+    lim = Limiter(threshold=-3.0, fs=FS)
+    gen = torch.Generator().manual_seed(4)
+    mono = torch.randn(1, 8000, generator=gen, dtype=torch.float64) * 2.0
+    y = lim(mono.repeat(2, 1))
+    torch.testing.assert_close(y[0], y[1])
+
+
+# --------------------------------------------------------------------------- #
+# Lazy fs + validation
+# --------------------------------------------------------------------------- #
+def test_fs_required():
+    with pytest.raises(ValueError, match="Sample rate"):
+        Limiter(threshold=-1.0)(torch.randn(1, 1000))
+
+
+def test_fs_recompute_on_change():
+    lim = Limiter(threshold=-1.0, fs=FS)
+    x = torch.randn(1, 4000, dtype=torch.float64) * 2.0
+    lim(x)
+    lim.fs = 96000
+    lim(x)
+    assert lim._last_fs == 96000
+    assert lim._lookahead_samples == round(0.005 * 96000)
+
+
+@pytest.mark.parametrize("kwargs", [{"lookahead": -1.0}, {"release": -1.0}, {"fs": 0}])
+def test_invalid_params_raise(kwargs):
+    with pytest.raises(ValueError):
+        Limiter(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# CPU / CUDA parity
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("lookahead", [0.0, 0.005])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_cpu_cuda_parity(lookahead, dtype):
+    lim_cpu = Limiter(threshold=-3.0, lookahead=lookahead, release=0.05, fs=FS)
+    lim_cuda = Limiter(threshold=-3.0, lookahead=lookahead, release=0.05, fs=FS)
+    gen = torch.Generator().manual_seed(7)
+    x = torch.randn(8, 16000, generator=gen, dtype=dtype) * 2.0
+    y_cpu = lim_cpu(x)
+    y_cuda = lim_cuda(x.cuda()).cpu()
+    tol = {"rtol": 1e-4, "atol": 1e-5} if dtype == torch.float32 else {"rtol": 1e-9, "atol": 1e-10}
+    torch.testing.assert_close(y_cpu, y_cuda, **tol)


### PR DESCRIPTION
## What
`Limiter` — a look-ahead brick-wall peak limiter that **guarantees `|y| <= threshold`** (a true brick wall) while staying transparent.

## Why (#31)
Completes the dynamics family (`Compressor` #30, `Expander`/`Gate` #32). `Compressor(ratio=inf)` is a zero-look-ahead limiter that can overshoot a single sample before its gain reacts; a real limiter must never exceed its ceiling.

## How
- The look-ahead windowed peak `max(|x[n..n+L]|)` is computed with a **vectorised forward max-pool** (CPU + CUDA), so the gain starts pulling down *before* a peak arrives — no transient overshoot, no click.
- The native `limiter_forward` kernel runs only the sequential gain recurrence: attack/release-smooth the gain toward that windowed target, then a **per-sample clamp** `g_out = min(g, threshold/|x[n]|)` enforces the ceiling exactly. Since `|x[n]| <= peak_env[n]`, `|y| <= threshold` **always** — the smoothing can't break the wall.
- CPU (OpenMP) + CUDA (one thread/channel, FP32/FP64); MSVC-safe (`TORCHFX_RESTRICT`, no `omp simd` / `omp_get_max_threads`).

## Correctness
- `tests/test_limiter.py` (33 cases): brick-wall guarantee across thresholds × scales (incl. 10× over full scale), transients/bursts, over-full-scale sine, `lookahead=0`, below-threshold passthrough, look-ahead pre-duck vs no-look-ahead, release recovery, shapes/dtypes, validation.
- **CPU/CUDA parity** on an RTX 3070.
- Full suite: **1331 passed (CPU)**, **1416 passed (GPU)**.

True-peak (oversampled inter-sample) detection is left as a documented follow-up.

Closes #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)