### PR TITLE
🔧 Free runner disk space before CUDA wheel build (#74)

### DIFF
--- a/.github/workflows/wheels-cuda.yml
+++ b/.github/workflows/wheels-cuda.yml
@@ -97,6 +97,19 @@ jobs:
         --exclude 'libnvJitLink.so*'
 
     steps:
+      # The CUDA wheel build installs the CUDA toolkit (dnf) plus a multi-GB CUDA
+      # torch wheel (pip) inside the manylinux container, whose writable layer lives
+      # on the runner's root filesystem. With the runner's default ~14 GB free that
+      # intermittently exhausts disk ("No space left on device"). Reclaim the
+      # preinstalled toolchains we don't use (~25 GB) first. See #74.
+      - name: Free up runner disk space
+        run: |
+          echo "disk before:"; df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+                      /opt/hostedtoolcache /usr/local/share/boost /usr/lib/jvm \
+                      /usr/share/swift || true
+          echo "disk after:"; df -h /
+
       - uses: actions/checkout@v4
 
       - name: Build wheels


### PR DESCRIPTION
## What
A disk-reclaim step in the CUDA wheel build (`wheels-cuda.yml`) before `cibuildwheel`.

## Why (#74)
The `cu124` / `cu128` wheel jobs intermittently fail with `[Errno 28] No space left on device` during `pip install torch`: the CUDA toolkit (`dnf install`) + the multi-GB CUDA torch wheel + the build exhaust the runner's ~14 GB free (the manylinux container's writable layer lives on the runner's `/`). Hit on **#71** (cu128) and **#73** (cu124); both passed only on rerun.

## How
Remove the preinstalled toolchains the build never uses — .NET, GHC/Haskell, Android SDK, the hosted tool cache, Boost, JVM, Swift (~25 GB) — before the build, with `df -h /` before/after so the reclaimed space is visible in the logs.

Only `wheels-cuda.yml` is touched (the CPU wheels in `wheels.yml` don't hit this). Because this PR edits `wheels-cuda.yml`, its own CI run builds the CUDA wheels and exercises the fix.

Closes #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)