### PR TITLE
✨ batch_process — batched multi-signal processing (#19)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`torchfx.batch_process(waves, effect)` — batched multi-signal processing.** Applies an
+  effect to many `Wave` signals in a **single** native kernel launch by padding them to a
+  common length and concatenating on the channel dimension (the causal per-channel kernels
+  make this numerically identical to processing each signal separately). Fills the GPU and
+  amortises Python dispatch + OpenMP setup — **2.5–4.1× faster on CPU** for 8–512 stereo
+  files, more on GPU. For per-channel-independent effects (filters, `Gain`, dynamics);
+  see `benchmarks/bench_batch.py`. (Resolves #19.)
 - **`Limiter` — look-ahead brick-wall peak limiter.** Guarantees `|y| <= threshold` (a
   true brick wall) while staying transparent: a short `lookahead` reduces the gain
   *before* a peak (a vectorised forward max-pool computes the look-ahead window), the gain

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,9 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   effect to many `Wave` signals in a **single** native kernel launch by padding them to a
   common length and concatenating on the channel dimension (the causal per-channel kernels
   make this numerically identical to processing each signal separately). Fills the GPU and
-  amortises Python dispatch + OpenMP setup — **2.5–4.1× faster on CPU** for 8–512 stereo
-  files, more on GPU. For per-channel-independent effects (filters, `Gain`, dynamics);
-  see `benchmarks/bench_batch.py`. (Resolves #19.)
+  amortises Python dispatch + OpenMP setup — measured **~2.5–7× faster on CPU** and
+  **~3–4× on GPU** for 8–512 stereo files (8th-order Butterworth). For
+  per-channel-independent effects (filters, `Gain`, dynamics); see
+  `benchmarks/bench_batch.py`. (Resolves #19.)
 - **`Limiter` — look-ahead brick-wall peak limiter.** Guarantees `|y| <= threshold` (a
   true brick wall) while staying transparent: a short `lookahead` reduces the gain
   *before* a peak (a vectorised forward max-pool computes the look-ahead window), the gain

--- a/benchmarks/bench_batch.py
+++ b/benchmarks/bench_batch.py
@@ -28,7 +28,7 @@ def _design():
 
 def _bench(device: str, n_files: int, channels: int, samples: int, reps: int = 5):
     waves = [
-        fx.Wave(torch.randn(channels, samples, dtype=torch.float32, device=device), FS)
+        fx.Wave(torch.randn(channels, samples, dtype=torch.float32), FS, device=device)
         for _ in range(n_files)
     ]
 

--- a/benchmarks/bench_batch.py
+++ b/benchmarks/bench_batch.py
@@ -1,0 +1,67 @@
+"""Benchmark: batched multi-signal processing vs one-at-a-time (issue #19).
+
+Processing many short signals one at a time underuses the GPU (few threads per launch,
+one launch per file). ``fx.batch_process`` concatenates them on the channel dimension and
+issues a single launch over all channels. This script reports the wall-clock of both for a
+sweep of file counts, on CPU and (if available) CUDA.
+
+Run::
+
+    uv run python benchmarks/bench_batch.py
+"""
+
+from __future__ import annotations
+
+import time
+
+import torch
+
+import torchfx as fx
+from torchfx.filter.iir import LoButterworth
+
+FS = 48000
+
+
+def _design():
+    return LoButterworth(4000, order=8)
+
+
+def _bench(device: str, n_files: int, channels: int, samples: int, reps: int = 5):
+    waves = [
+        fx.Wave(torch.randn(channels, samples, dtype=torch.float32, device=device), FS)
+        for _ in range(n_files)
+    ]
+
+    def one_by_one():
+        return [(w | _design()).ys for w in waves]
+
+    def batched():
+        return fx.batch_process(waves, _design())
+
+    def timeit(fn):
+        fn()  # warmup
+        if device == "cuda":
+            torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        for _ in range(reps):
+            fn()
+        if device == "cuda":
+            torch.cuda.synchronize()
+        return (time.perf_counter() - t0) / reps * 1e3  # ms
+
+    return timeit(one_by_one), timeit(batched)
+
+
+def main() -> None:
+    devices = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
+    channels, samples = 2, FS  # stereo, 1 s
+    for dev in devices:
+        print(f"\n# {dev} | stereo x 1s @ {FS} Hz | 8th-order Butterworth")
+        print("# files | one-by-one |   batched |  speedup")
+        for n in (8, 32, 128, 512):
+            t_obo, t_bat = _bench(dev, n, channels, samples)
+            print(f"  {n:5d} | {t_obo:8.2f}ms | {t_bat:7.2f}ms | {t_obo / t_bat:6.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/source/guides/developer/roadmap.md
+++ b/docs/source/guides/developer/roadmap.md
@@ -423,8 +423,8 @@ TorchFX v1.0.0 will be a production-ready, GPU-accelerated audio DSP library wit
 - [x] **Multi-file batch processing** (#19) — `torchfx.batch_process(waves, effect)` pads
   signals to a common length, concatenates them on the channel dimension, and runs the
   effect in a **single** native dispatch over all channels (causal per-channel kernels +
-  trailing zero-pad ⇒ numerically identical to per-file). Measured **2.5–4.1× faster on
-  CPU** for 8–512 stereo files (8th-order Butterworth); larger on GPU via occupancy. See
+  trailing zero-pad ⇒ numerically identical to per-file). Measured **~2.5–7× on CPU and
+  ~3–4× on GPU** for 8–512 stereo files (8th-order Butterworth). See
   `benchmarks/bench_batch.py`.
 
 ### 4.5 Performance Benchmarking ✅

--- a/docs/source/guides/developer/roadmap.md
+++ b/docs/source/guides/developer/roadmap.md
@@ -420,9 +420,12 @@ TorchFX v1.0.0 will be a production-ready, GPU-accelerated audio DSP library wit
   - ✅ Reverb op fusion (5 tensor ops → 2)
   - ✅ Delay wet/dry mix via `torch.lerp` (3 ops → 1)
 
-- [ ] **Multi-file batch processing**
-  - Process multiple files in single kernel launch
-  - Maximize GPU occupancy
+- [x] **Multi-file batch processing** (#19) — `torchfx.batch_process(waves, effect)` pads
+  signals to a common length, concatenates them on the channel dimension, and runs the
+  effect in a **single** native dispatch over all channels (causal per-channel kernels +
+  trailing zero-pad ⇒ numerically identical to per-file). Measured **2.5–4.1× faster on
+  CPU** for 8–512 stereo files (8th-order Butterworth); larger on GPU via occupancy. See
+  `benchmarks/bench_batch.py`.
 
 ### 4.5 Performance Benchmarking ✅
 

--- a/src/torchfx/__init__.py
+++ b/src/torchfx/__init__.py
@@ -5,6 +5,7 @@ import torchfx.realtime as realtime
 import torchfx.typing as typing
 import torchfx.validation as validation
 from torchfx._ops import is_native_available
+from torchfx.batch import batch_process
 from torchfx.chain import FilterChain
 from torchfx.effect import FX
 from torchfx.wave import Wave
@@ -20,4 +21,5 @@ __all__ = [
     "logging",
     "realtime",
     "is_native_available",
+    "batch_process",
 ]

--- a/src/torchfx/batch.py
+++ b/src/torchfx/batch.py
@@ -1,0 +1,123 @@
+"""Batched multi-signal processing in a single kernel launch.
+
+Processing many short signals one at a time underuses the GPU: a stereo file is two
+threads on a device with thousands of cores, and each file is its own kernel launch.
+:func:`batch_process` instead pads the signals to a common length, concatenates them
+along the channel dimension into one ``(sum_channels, max_samples)`` tensor, and runs the
+effect **once** — a single launch over all channels at high occupancy. The native filter
+kernels treat every channel independently and are causal, so the trailing zero-pad never
+affects a signal's valid region; the result is numerically identical to processing each
+signal separately.
+
+Examples
+--------
+>>> import torch
+>>> import torchfx as fx
+>>> waves = [fx.Wave(torch.randn(1, 44100), 44100) for _ in range(64)]
+>>> out = fx.batch_process(waves, fx.filter.LoButterworth(4000, order=8))
+>>> len(out)
+64
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+from torch import nn
+
+from torchfx.wave import Wave
+
+__all__ = ["batch_process"]
+
+
+def batch_process(waves: Sequence[Wave], effect: nn.Module) -> list[Wave]:
+    """Apply ``effect`` to many :class:`~torchfx.Wave` signals in one batched launch.
+
+    Parameters
+    ----------
+    waves : Sequence[Wave]
+        Signals to process. All must share the same sampling rate and device. Lengths
+        and channel counts may differ.
+    effect : nn.Module
+        The effect or filter chain to apply (e.g. a filter, ``f1 | f2``, or any
+        :class:`~torchfx.FX`). It is applied to every signal with the shared ``fs``.
+
+    Returns
+    -------
+    list[Wave]
+        One output ``Wave`` per input, in the same order, each trimmed back to its
+        original length and channel count (and carrying its original metadata).
+
+    Raises
+    ------
+    ValueError
+        If ``waves`` is empty, or the signals do not share a single ``fs`` / device.
+
+    Notes
+    -----
+    Equivalent to ``[w | effect for w in waves]`` but issues a **single** native kernel
+    dispatch over the concatenated channels instead of one per signal, which fills the
+    GPU (and amortises Python dispatch + OpenMP setup on CPU) when many signals are
+    processed together — the CLI batch / watch workloads.
+
+    This holds only for effects that process each channel **independently** and causally
+    — filters, ``Gain``, the dynamics effects, per-channel ``Normalize``. Effects that
+    aggregate across channels or the whole signal (a global-peak ``Normalize``, mixing)
+    would see all the batched signals at once and are **not** batch-safe; apply those per
+    signal.
+
+    Examples
+    --------
+    >>> import torch
+    >>> import torchfx as fx
+    >>> waves = [fx.Wave(torch.randn(2, 24000), 48000) for _ in range(8)]
+    >>> out = fx.batch_process(waves, fx.effect.Gain(0.5))
+    >>> [w.ys.shape for w in out][0]
+    torch.Size([2, 24000])
+
+    """
+    if len(waves) == 0:
+        raise ValueError("batch_process requires at least one Wave.")
+
+    fs = waves[0].fs
+    device = waves[0].ys.device
+    dtype = waves[0].ys.dtype
+    for i, w in enumerate(waves):
+        if w.fs != fs:
+            raise ValueError(
+                f"All waves must share one sampling rate; wave[0].fs={fs} but "
+                f"wave[{i}].fs={w.fs}. Resample first or group by fs."
+            )
+        if w.ys.device != device:
+            raise ValueError(
+                f"All waves must be on the same device; wave[0] on {device} but "
+                f"wave[{i}] on {w.ys.device}."
+            )
+
+    lengths = [w.ys.shape[1] for w in waves]
+    channels = [w.ys.shape[0] for w in waves]
+    max_len = max(lengths)
+
+    # Pad each signal's tail with zeros to the common length, then stack on channels.
+    padded = [
+        (
+            w.ys
+            if w.ys.shape[1] == max_len
+            else torch.nn.functional.pad(w.ys, (0, max_len - w.ys.shape[1]))
+        )
+        for w in waves
+    ]
+    stacked = torch.cat(padded, dim=0).to(dtype=dtype)
+
+    # One pipeline evaluation over all channels => a single native dispatch.
+    processed = (Wave(stacked, fs, device=device) | effect).ys
+
+    results: list[Wave] = []
+    offset = 0
+    for c, length, w in zip(channels, lengths, waves, strict=True):
+        segment = processed[offset : offset + c, :length]
+        results.append(Wave(segment, fs, device=device, metadata=w.metadata))
+        offset += c
+    return results

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,135 @@
+"""Tests for batched multi-signal processing (issue #19)."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+import torch
+
+import torchfx as fx
+from torchfx import Wave, _ops, batch_process
+from torchfx.effect import Gain
+from torchfx.filter.iir import HiButterworth, LoButterworth
+
+FS = 48000
+
+
+@contextmanager
+def count_sos():
+    """Count native SOS dispatches (to assert the batch is a single launch)."""
+    n = {"sos": 0}
+    orig = _ops.parallel_iir_forward
+
+    def wrap(*a: Any, **k: Any) -> Any:
+        n["sos"] += 1
+        return orig(*a, **k)
+
+    _ops.parallel_iir_forward = wrap
+    try:
+        yield n
+    finally:
+        _ops.parallel_iir_forward = orig
+
+
+def _wave(c: int, t: int, seed: int) -> Wave:
+    gen = torch.Generator().manual_seed(seed)
+    return Wave(torch.randn(c, t, generator=gen, dtype=torch.float64), FS)
+
+
+# --------------------------------------------------------------------------- #
+# Numerical equivalence to per-file processing
+# --------------------------------------------------------------------------- #
+def test_batch_equals_per_file_filter():
+    specs = [(1, 4000), (2, 6000), (1, 5000), (2, 3000)]
+    waves = [_wave(c, t, i) for i, (c, t) in enumerate(specs)]
+    out = batch_process(waves, LoButterworth(4000, order=8))
+    assert len(out) == len(waves)
+    for w, o in zip(waves, out, strict=True):
+        ref = (w | LoButterworth(4000, order=8)).ys
+        assert o.ys.shape == w.ys.shape
+        torch.testing.assert_close(o.ys, ref, rtol=1e-9, atol=1e-12)
+
+
+def test_batch_equals_per_file_chain():
+    waves = [_wave(2, 4000 + 500 * i, i) for i in range(5)]
+    out = batch_process(waves, HiButterworth(120, order=4) | LoButterworth(8000, order=4))
+    for w, o in zip(waves, out, strict=True):
+        ref = (w | (HiButterworth(120, order=4) | LoButterworth(8000, order=4))).ys
+        torch.testing.assert_close(o.ys, ref, rtol=1e-9, atol=1e-12)
+
+
+def test_batch_equals_per_file_gain():
+    waves = [_wave(1, 2000, i) for i in range(4)]
+    out = batch_process(waves, Gain(0.5))
+    for w, o in zip(waves, out, strict=True):
+        torch.testing.assert_close(o.ys, w.ys * 0.5, rtol=1e-9, atol=1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# Single dispatch (the whole point: one launch for the batch)
+# --------------------------------------------------------------------------- #
+def test_batch_is_single_dispatch():
+    waves = [_wave(2, 4000, i) for i in range(16)]
+    with count_sos() as n:
+        batch_process(waves, LoButterworth(4000, order=8))
+    assert n["sos"] == 1, f"batch of 16 should be one SOS dispatch, got {n['sos']}"
+
+
+def test_per_file_is_n_dispatches():
+    waves = [_wave(2, 4000, i) for i in range(16)]
+    with count_sos() as n:
+        for w in waves:
+            _ = (w | LoButterworth(4000, order=8)).ys
+    assert n["sos"] == 16
+
+
+# --------------------------------------------------------------------------- #
+# Shapes, metadata, validation
+# --------------------------------------------------------------------------- #
+def test_preserves_shapes_and_metadata():
+    w0 = Wave(torch.randn(2, 7000, dtype=torch.float64), FS, metadata={"src": "a"})
+    w1 = Wave(torch.randn(1, 3000, dtype=torch.float64), FS, metadata={"src": "b"})
+    out = batch_process([w0, w1], Gain(1.0))
+    assert out[0].ys.shape == (2, 7000)
+    assert out[1].ys.shape == (1, 3000)
+    assert out[0].metadata == {"src": "a"}
+    assert out[1].metadata == {"src": "b"}
+
+
+def test_single_wave_batch():
+    w = _wave(2, 5000, 0)
+    out = batch_process([w], LoButterworth(4000, order=6))
+    torch.testing.assert_close(out[0].ys, (w | LoButterworth(4000, order=6)).ys)
+
+
+def test_empty_raises():
+    with pytest.raises(ValueError, match="at least one"):
+        batch_process([], Gain(1.0))
+
+
+def test_mixed_fs_raises():
+    w0 = Wave(torch.randn(1, 1000, dtype=torch.float64), 48000)
+    w1 = Wave(torch.randn(1, 1000, dtype=torch.float64), 44100)
+    with pytest.raises(ValueError, match="sampling rate"):
+        batch_process([w0, w1], Gain(1.0))
+
+
+def test_exported_at_top_level():
+    assert fx.batch_process is batch_process
+
+
+# --------------------------------------------------------------------------- #
+# GPU: batch == per-file == CPU, in one launch
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_batch_gpu_matches_cpu():
+    specs = [(1, 4000), (2, 6000), (2, 5000)]
+    waves_cpu = [_wave(c, t, i) for i, (c, t) in enumerate(specs)]
+    waves_gpu = [Wave(w.ys.cuda(), FS) for w in waves_cpu]
+    out_cpu = batch_process(waves_cpu, LoButterworth(4000, order=8))
+    out_gpu = batch_process(waves_gpu, LoButterworth(4000, order=8))
+    for oc, og in zip(out_cpu, out_gpu, strict=True):
+        assert og.ys.is_cuda
+        torch.testing.assert_close(oc.ys, og.ys.cpu(), rtol=1e-9, atol=1e-10)

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -127,7 +127,7 @@ def test_exported_at_top_level():
 def test_batch_gpu_matches_cpu():
     specs = [(1, 4000), (2, 6000), (2, 5000)]
     waves_cpu = [_wave(c, t, i) for i, (c, t) in enumerate(specs)]
-    waves_gpu = [Wave(w.ys.cuda(), FS) for w in waves_cpu]
+    waves_gpu = [Wave(w.ys, FS, device="cuda") for w in waves_cpu]
     out_cpu = batch_process(waves_cpu, LoButterworth(4000, order=8))
     out_gpu = batch_process(waves_gpu, LoButterworth(4000, order=8))
     for oc, og in zip(out_cpu, out_gpu, strict=True):


### PR DESCRIPTION
## What
`torchfx.batch_process(waves, effect)` — apply an effect to many `Wave` signals in a **single** native kernel launch.

## Why (#19)
Processing many short signals one at a time underuses the GPU (a stereo file is 2 threads on a device with thousands of cores, each file its own launch) — relevant to the CLI batch / watch modes.

## How
Pad each signal to a common length, concatenate on the channel dimension into one `(ΣC, max_T)` tensor, run the effect **once**, then slice + trim back. The causal per-channel kernels make this **numerically identical** to processing each signal separately (the trailing zero-pad never touches a signal's valid region).

## Results (8th-order Butterworth, 8–512 stereo files; `benchmarks/bench_batch.py`)
| files | CPU | GPU (RTX 3070) |
|---|---|---|
| 8 | 5.6× | 3.0× |
| 128 | 4.8× | 3.8× |
| 512 | 7.1× | 3.9× |

## Correctness
- `tests/test_batch.py` (11): equivalence to per-file for filter / chain / `Gain`; single-dispatch invariant (batch = 1 native call, per-file = N); shapes + metadata; validation; **GPU↔CPU parity** on an RTX 3070.
- Full suite 1349 passed. Documented constraint: batch-safe for per-channel-independent effects (filters, `Gain`, dynamics); a global-peak `Normalize` is not.

Closes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)