### PR TITLE
✅ Automated release notes from CHANGELOG on tag (#29)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,23 @@ jobs:
           git tag -a "$tag" -m "Release $tag"
           git push origin "$tag"
 
+      # Publish a GitHub Release whose notes are the CHANGELOG section for this
+      # version (tools/extract_changelog.py). Falls back to a placeholder if the
+      # CHANGELOG has no matching `## [X.Y.Z]` header yet.
+      - name: Create GitHub Release with CHANGELOG notes
+        if: steps.check.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="v${{ steps.ver.outputs.version }}"
+          if python tools/extract_changelog.py "${{ steps.ver.outputs.version }}" > release-notes.md; then
+            echo "Using the CHANGELOG section for ${{ steps.ver.outputs.version }}."
+          else
+            echo "::warning::No CHANGELOG section for ${{ steps.ver.outputs.version }}; using a placeholder."
+            printf 'Release %s. See the CHANGELOG for details.\n' "$tag" > release-notes.md
+          fi
+          gh release create "$tag" --title "$tag" --notes-file release-notes.md --verify-tag
+
       # Tag pushes from GITHUB_TOKEN do not retrigger workflows, so kick the
       # wheel builds off explicitly. Each runs with --ref pointing at the
       # new tag, so github.ref inside wheels.yml/wheels-cuda.yml is

--- a/docs/source/guides/developer/releasing.md
+++ b/docs/source/guides/developer/releasing.md
@@ -11,6 +11,7 @@ When the merge commit lands on `master`, [`release.yml`](https://github.com/matt
 
 - Reads the new version out of `pyproject.toml`.
 - If a tag `v<version>` doesn't exist yet, it creates and pushes one (`v0.5.4`, `v0.6.0`, ...).
+- Creates a **GitHub Release** for the tag whose notes are the `## [<version>]` section of the `CHANGELOG`, extracted by [`tools/extract_changelog.py`](https://github.com/matteospanio/torchfx/blob/master/tools/extract_changelog.py). So the CHANGELOG entry you write in step 1 *is* the release notes — make sure it has a matching `## [<version>]` header (a placeholder is used if it doesn't).
 - Dispatches [`wheels.yml`](https://github.com/matteospanio/torchfx/blob/master/.github/workflows/wheels.yml) and [`wheels-cuda.yml`](https://github.com/matteospanio/torchfx/blob/master/.github/workflows/wheels-cuda.yml) against the new tag.
 
 The wheel workflows then:
@@ -24,6 +25,7 @@ If you re-merge to `master` without changing the version, `release.yml` is a no-
 flowchart LR
     PR["Version-bump PR"] --> Merge["Merge to master"]
     Merge --> Release["release.yml<br/>(detects bump,<br/>tags vX.Y.Z)"]
+    Release --> Notes["GitHub Release<br/>(CHANGELOG section)"]
     Release -->|workflow_dispatch| CPU["wheels.yml<br/>cibuildwheel × 4 OSes"]
     Release -->|workflow_dispatch| GPU["wheels-cuda.yml<br/>cu124 + cu128"]
     CPU --> PyPI["PyPI<br/>(trusted publishing)"]

--- a/docs/source/guides/developer/roadmap.md
+++ b/docs/source/guides/developer/roadmap.md
@@ -680,9 +680,10 @@ Each item lists its difficulty and expected impact; none block a release.
   - Self-hosted or cloud GPU
   - CUDA tests and benchmarks
 
-- [ ] **Automated releases**
-  - PyPI publishing on tag
-  - Changelog generation
+- [x] **Automated releases** (#29) — `release.yml` already auto-tags on a `pyproject.toml`
+  version bump and the wheel workflows publish to PyPI / the CUDA index on the tag. Now it
+  also publishes a **GitHub Release** whose notes are the `## [<version>]` CHANGELOG
+  section (`tools/extract_changelog.py`). See the developer releasing guide.
 
 ---
 

--- a/tests/test_extract_changelog.py
+++ b/tests/test_extract_changelog.py
@@ -1,0 +1,98 @@
+"""Tests for the CHANGELOG release-notes extractor (issue #29)."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "tools" / "extract_changelog.py"
+
+
+def _load_extract():
+    spec = importlib.util.spec_from_file_location("extract_changelog", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.extract
+
+
+extract = _load_extract()
+
+SAMPLE = """# Changelog
+
+## [Unreleased]
+
+### Added
+
+- pending thing
+
+## [0.7.0] - 2026-06-09
+
+### Added
+
+- shiny feature
+
+### Fixed
+
+- a bug
+
+## [0.6.0] - 2026-06-04
+
+### Added
+
+- older feature
+"""
+
+
+def test_extract_middle_version():
+    out = extract(SAMPLE, "0.7.0")
+    assert "shiny feature" in out
+    assert "a bug" in out
+    assert "older feature" not in out  # stops at the next "## " header
+    assert "pending thing" not in out  # does not bleed into the previous section
+
+
+def test_extract_last_version_to_eof():
+    assert "older feature" in extract(SAMPLE, "0.6.0")
+
+
+def test_extract_unreleased():
+    assert "pending thing" in extract(SAMPLE, "Unreleased")
+
+
+def test_missing_version_raises():
+    with pytest.raises(KeyError):
+        extract(SAMPLE, "9.9.9")
+
+
+def test_cli_found(tmp_path):
+    cl = tmp_path / "CHANGELOG"
+    cl.write_text(SAMPLE)
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), "0.7.0", "--changelog", str(cl)],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0
+    assert "shiny feature" in res.stdout
+
+
+def test_cli_missing_exits_nonzero(tmp_path):
+    cl = tmp_path / "CHANGELOG"
+    cl.write_text(SAMPLE)
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), "9.9.9", "--changelog", str(cl)],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 1
+
+
+def test_real_changelog_section_non_empty():
+    text = (ROOT / "CHANGELOG").read_text(encoding="utf-8")
+    assert extract(text, "0.6.0").strip()

--- a/tools/extract_changelog.py
+++ b/tools/extract_changelog.py
@@ -1,0 +1,62 @@
+"""Extract one version's section from the CHANGELOG, for GitHub release notes.
+
+The release workflow (``.github/workflows/release.yml``) runs this on the version it is
+tagging and feeds the output to ``gh release create --notes-file``. Given a ``CHANGELOG``
+with `Keep a Changelog`-style headers::
+
+    ## [0.7.0] - 2026-06-09
+    ### Added
+    - ...
+
+    ## [0.6.0] - 2026-06-04
+    ...
+
+``extract_changelog.py 0.7.0`` prints everything under ``## [0.7.0]`` up to (but not
+including) the next ``## `` header.
+
+Usage::
+
+    python tools/extract_changelog.py 0.7.0 [--changelog CHANGELOG]
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def extract(changelog: str, version: str) -> str:
+    """Return the release-notes body for ``version`` (raises ``KeyError`` if absent)."""
+    header = re.compile(r"^## \[" + re.escape(version) + r"\]")
+    lines = changelog.splitlines()
+    start = next((i for i, line in enumerate(lines) if header.match(line)), None)
+    if start is None:
+        raise KeyError(f"No CHANGELOG section for version {version!r}.")
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        if line.startswith("## "):
+            break
+        body.append(line)
+    return "\n".join(body).strip("\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="version to extract, e.g. 0.7.0 (no leading 'v')")
+    parser.add_argument("--changelog", default="CHANGELOG", help="path to the changelog file")
+    args = parser.parse_args(argv)
+
+    text = Path(args.changelog).read_text(encoding="utf-8")
+    try:
+        print(extract(text, args.version))
+    except KeyError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What
On release, publish a **GitHub Release** whose notes are the version's CHANGELOG section.

## Why (#29)
`release.yml` already auto-tags on a `pyproject.toml` version bump, and `wheels.yml` / `wheels-cuda.yml` already publish to **PyPI** and the CUDA index on the tag. The missing piece of #29 was *release-note generation* — this adds exactly that.

## How
- **`tools/extract_changelog.py`** — a small, dependency-free extractor: prints everything under `## [<version>]` up to the next `## ` header.
- **`release.yml`** — after pushing the tag, runs the extractor and `gh release create "$tag" --notes-file …` (placeholder fallback if the CHANGELOG has no matching header). So the CHANGELOG entry you write *is* the release notes.

## Validation
- `tests/test_extract_changelog.py` (7): middle / last / `Unreleased` sections, missing-version error, CLI exit codes, the real `CHANGELOG`. Full suite **1356 passed**; `release.yml` parses as valid YAML.
- The `gh release create` step fires on the next real version bump (needs a tag), but the extraction it depends on is fully tested.

Documented in the developer releasing guide (flow + diagram). No CHANGELOG entry (release tooling, not a library change).

Closes #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)