### PR TITLE
📝 Profiling guide (#22) + Codecov config (#26)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+# Codecov configuration.
+#
+# CI (.github/workflows/ci.yml) runs the suite under coverage and uploads coverage.xml,
+# which measures `src/torchfx` (see [tool.coverage] in pyproject.toml). The absolute level
+# is gated in CI by coverage's own `fail_under = 87`; the statuses below add per-PR signal
+# on top of that — guard against drops and keep new code covered — without being flaky.
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto        # don't drop below the base branch...
+        threshold: 1%       # ...by more than 1% (run-to-run noise margin)
+    patch:
+      default:
+        target: 80%         # changed lines in a PR should be well covered
+        threshold: 5%
+
+comment:
+  layout: "reach, diff, files"
+  require_changes: true     # only comment when coverage actually changes
+
+# Mirror coverage's `omit`: the sounddevice backend is unreachable on the CPU-only CI box.
+ignore:
+  - "src/torchfx/realtime/sounddevice_backend.py"

--- a/docs/source/guides/developer/index.md
+++ b/docs/source/guides/developer/index.md
@@ -10,6 +10,7 @@ Resources and guidelines for TorchFX contributors and developers.
 project-structure
 testing
 benchmarking
+profiling
 documentation
 style_guide
 releasing
@@ -21,6 +22,7 @@ roadmap
 - [Project Structure](project-structure.md) - Repository organization and module architecture
 - [Testing](testing.md) - Test infrastructure, patterns, and coverage
 - [Benchmarking](benchmarking.md) - Performance measurement and comparison
+- [Profiling](profiling.md) - Diagnosing where time goes in a pipeline, and the usual fixes
 - [Documentation](documentation.md) - Documentation build system and writing guide
 - [Style Guide](style_guide.md) - Coding standards and best practices
 - [Releasing](releasing.md) - How a version bump becomes a published release

--- a/docs/source/guides/developer/profiling.md
+++ b/docs/source/guides/developer/profiling.md
@@ -1,0 +1,107 @@
+# Profiling pipelines
+
+How to find where time goes in a TorchFX pipeline, and the usual fixes. For *comparative*
+measurement against a baseline see {doc}`/guides/developer/benchmarking`; this guide is
+about diagnosing a single pipeline.
+
+## Time it correctly first
+
+Three things will give you wrong numbers if you skip them:
+
+- **Warm up.** Filters compute their coefficients lazily on the *first* `forward`, and the
+  native extension's first call pays one-time setup. Run the pipeline a few times before
+  timing.
+- **Synchronise CUDA.** Kernel launches are asynchronous, so `perf_counter` around a GPU
+  call measures only the *launch*, not the work. Call `torch.cuda.synchronize()` before
+  reading the clock.
+- **Use the median**, not a single sample — the OS scheduler adds multi-millisecond
+  outliers (see the realtime tail discussion in the benchmarking guide).
+
+```python
+import time
+import torch
+import torchfx as fx
+
+wave = fx.Wave(torch.randn(2, 480_000), 48_000)
+chain = fx.filter.HiButterworth(80, order=4) | fx.filter.LoButterworth(12_000, order=8)
+
+for _ in range(3):                      # warm up (lazy coeffs + first-call setup)
+    _ = wave | chain
+
+samples = []
+for _ in range(20):
+    torch.cuda.synchronize() if wave.ys.is_cuda else None
+    t0 = time.perf_counter_ns()
+    _ = wave | chain
+    torch.cuda.synchronize() if wave.ys.is_cuda else None
+    samples.append(time.perf_counter_ns() - t0)
+samples.sort()
+print(f"median {samples[len(samples)//2] / 1e6:.3f} ms")
+```
+
+## The kernel timeline with `torch.profiler`
+
+To see *which* operations dominate (and, on CUDA, the launch vs. compute split):
+
+```python
+from torch.profiler import profile, ProfilerActivity
+
+acts = [ProfilerActivity.CPU]
+if wave.ys.is_cuda:
+    acts.append(ProfilerActivity.CUDA)
+
+with profile(activities=acts, record_shapes=True) as prof:
+    for _ in range(10):
+        _ = wave | chain
+
+print(prof.key_averages().table(sort_by="self_cuda_time_total", row_limit=15))
+# CPU-only: sort_by="self_cpu_time_total"
+```
+
+Look for the `torchfx_ext::` entries (`sos_forward`, `biquad_forward`, …) — those are the
+native kernels. A long tail of many short native calls usually means the chain **didn't
+fuse** (see below). Export a Chrome trace with `prof.export_chrome_trace("trace.json")`
+and open it in `chrome://tracing` for a visual timeline.
+
+## Counting native dispatches
+
+The single most useful TorchFX-specific check: how many times does the pipeline cross into
+the native extension? A fused IIR cascade should be **one** dispatch regardless of depth.
+
+```bash
+uv run python tools/count_kernel_launches.py --depths 2,5,10,20
+```
+
+It reports `native_calls` (Python→C++ dispatches) and `cuda_launches` for the fused vs.
+unfused paths. In your own code, wrap the dispatch to count it (the mechanism
+`tests/test_perf_regression.py` uses):
+
+```python
+from torchfx import _ops
+
+orig = _ops.parallel_iir_forward
+calls = 0
+def counted(*a, **k):
+    global calls; calls += 1
+    return orig(*a, **k)
+_ops.parallel_iir_forward = counted
+_ = wave | chain
+print("SOS dispatches:", calls)   # 1 if the cascade fused
+_ops.parallel_iir_forward = orig
+```
+
+## Common bottlenecks and fixes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Many short `sos_forward` calls | IIR filters applied one at a time | Build the chain with `\|` so the deferred planner **fuses** consecutive IIR/biquads into one `FusedSOSCascade`; avoid forcing materialisation between them. |
+| GPU slower than expected on float32 in | Input upcast to float64 | Pass float32 tensors — the kernels dispatch on dtype and run the FP32 path (≈3× on consumer GPUs). |
+| High per-chunk latency on short GPU chunks | Per-section launch overhead dominates | Use `torchfx.realtime.CudaGraphRunner` to replay a fixed-shape forward as one graph launch. |
+| Throughput-bound over many short files | One launch per file, low occupancy | `torchfx.batch_process(waves, effect)` runs them in a single launch. |
+| Sequential vs. parallel scan crossover | Signal length near `PARALLEL_SCAN_THRESHOLD` | Tune the `threshold=` argument (dtype-aware default); `benchmarks/bench_threshold_sweep.py`. |
+
+## See also
+
+- {doc}`/guides/developer/benchmarking` — comparative benchmarking and the suite layout.
+- {doc}`/guides/developer/testing` — the deterministic perf-regression gates that keep
+  fusion from silently breaking.

--- a/docs/source/guides/developer/roadmap.md
+++ b/docs/source/guides/developer/roadmap.md
@@ -446,8 +446,9 @@ TorchFX v1.0.0 will be a production-ready, GPU-accelerated audio DSP library wit
   relative wall-time smoke. Avoids flaky absolute-timing baselines on shared runners; see
   the developer testing guide. (Absolute wall-time budgets would need a dedicated runner.)
 
-- [ ] **Profiling guides**
-  - Documentation for profiling pipelines
+- [x] **Profiling guides** (#22) — developer guide on diagnosing a pipeline: correct
+  warm-up/CUDA-sync timing, `torch.profiler` timelines, counting native dispatches to spot
+  un-fused chains, and a bottleneck→fix table. See the developer profiling guide.
 
 ### 4.6 Advanced Kernel Optimizations (Future)
 
@@ -668,7 +669,9 @@ Each item lists its difficulty and expected impact; none block a release.
 - [x] **Coverage reporting**
   - ✅ HTML coverage CI job on Python 3.12
   - ✅ `fail_under = 87` coverage gate enforced
-  - [ ] Codecov integration
+  - ✅ Codecov integration (#26) — CI uploads `coverage.xml` via `codecov-action`, README
+    badge, and a `codecov.yml` with project/patch status targets (ignoring the
+    CPU-unreachable sounddevice backend)
   - [ ] Coverage badge
 
 - [ ] **Multi-platform testing**


### PR DESCRIPTION
Two small v0.7.0 tooling/docs items in one PR. (#20 and #25 have been moved to **Backlog / Future** per the milestone triage.)

## #22 — Profiling guide
A developer guide (`docs/.../profiling.md`, linked in the guides index) for diagnosing a single pipeline:
- timing done correctly (warm-up for lazy coeffs, `torch.cuda.synchronize()`, medians);
- `torch.profiler` kernel timelines (CPU + CUDA);
- counting native dispatches to spot **un-fused** chains (the `count_kernel_launches` tool + the `_ops` wrap);
- a symptom → cause → fix table (un-fused IIR → deferred pipeline; FP64-on-GPU → FP32; short GPU chunks → `CudaGraphRunner`; many files → `batch_process`; scan crossover → `threshold=`).

Builds clean in Sphinx.

## #26 — Codecov integration
The upload (`codecov-action@v5` + `CODECOV_TOKEN` + `coverage.xml`) and the README badge were **already present** — the missing piece was config. Adds **`codecov.yml`**: project status `auto`/1% (guard against drops) + patch `80%`, ignoring the CPU-unreachable `sounddevice_backend.py` (mirrors `[tool.coverage]` `omit`). **Validated against Codecov's schema** (`Valid!`).

Closes #22, closes #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)