### PR TITLE
✨ Freeverb reverb (#18) + v0.7.0 release prep

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -65,6 +65,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path on both sm_86 (RTX 3070) and sm_89 (L40S); the decoupled look-back's forward
   progress is validated across 46–142 SMs.
 
+### Changed
+
+- **`Reverb` reworked into a Freeverb-style algorithmic reverb.** The single feedforward
+  comb is replaced by the classic Schroeder/Moorer structure — 8 parallel
+  low-pass-feedback comb filters summed through 4 series all-pass diffusers per channel —
+  for a dense, natural decay, in a native per-channel C++/CUDA kernel. **Breaking:** the
+  constructor is now `Reverb(room_size, damping, mix, fs)` (was `Reverb(delay, decay,
+  mix)`); it needs `fs` (supplied by a `Wave` pipeline) to scale the delay tunings. CLI
+  `reverb:room_size=…,damping=…,mix=…`. (Resolves #18.)
+
 ## [0.6.0] - 2026-06-04
 
 ### Added

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-09
+
 ### Added
 
 - **`torchfx.batch_process(waves, effect)` — batched multi-signal processing.** Applies an

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,8 @@ Python_add_library(torchfx_ext MODULE WITH_SOABI
   "${CSRC_DIR}/cpu/delay_cpu.cpp"
   "${CSRC_DIR}/cpu/compressor_cpu.cpp"
   "${CSRC_DIR}/cpu/expander_cpu.cpp"
-  "${CSRC_DIR}/cpu/limiter_cpu.cpp")
+  "${CSRC_DIR}/cpu/limiter_cpu.cpp"
+  "${CSRC_DIR}/cpu/reverb_cpu.cpp")
 
 if(TORCHFX_USE_CUDA)
   target_sources(torchfx_ext PRIVATE
@@ -94,7 +95,8 @@ if(TORCHFX_USE_CUDA)
     "${CSRC_DIR}/cuda/delay_forward.cu"
     "${CSRC_DIR}/cuda/compressor_forward.cu"
     "${CSRC_DIR}/cuda/expander_forward.cu"
-    "${CSRC_DIR}/cuda/limiter_forward.cu")
+    "${CSRC_DIR}/cuda/limiter_forward.cu"
+    "${CSRC_DIR}/cuda/reverb_forward.cu")
   target_compile_definitions(torchfx_ext PRIVATE WITH_CUDA)
   set_target_properties(torchfx_ext PROPERTIES CUDA_ARCHITECTURES "${TORCHFX_CUDA_ARCHS}")
 endif()

--- a/docs/source/guides/developer/roadmap.md
+++ b/docs/source/guides/developer/roadmap.md
@@ -393,9 +393,10 @@ TorchFX v1.0.0 will be a production-ready, GPU-accelerated audio DSP library wit
 - [x] **Optimized delay line**
   - ✅ CUDA delay forward kernel
 
-- [ ] **Reverb optimization**
-  - Parallel all-pass filters
-  - Fused feedback delay network
+- [x] **Reverb optimization** (#18) — `Reverb` reworked into a Freeverb-style network: 8
+  parallel low-pass-feedback comb filters + 4 series all-pass diffusers per channel, in a
+  fused native per-channel C++/CUDA kernel (ring buffers in per-channel scratch). Replaces
+  the single feedforward comb; breaking API (`room_size`/`damping`/`mix`/`fs`).
 
 ### 4.4 Batch Processing Optimizations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "torchfx"
-version = "0.6.0"
+version = "0.7.0"
 description = "A GPU accelerated library for audio DSP based on PyTorch"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/cli/commands/play.py
+++ b/src/cli/commands/play.py
@@ -33,7 +33,7 @@ def play_cmd(
     Examples
     --------
       torchfx play song.wav
-      torchfx play recording.wav -e normalize -e "reverb:decay=0.4"
+      torchfx play recording.wav -e normalize -e "reverb:room_size=0.4"
 
     """
     import numpy as np

--- a/src/cli/commands/preset.py
+++ b/src/cli/commands/preset.py
@@ -85,7 +85,7 @@ def preset_save_cmd(
     \b
     Examples
     --------
-      torchfx preset save mastering -e normalize -e "reverb:decay=0.4,mix=0.2"
+      torchfx preset save mastering -e normalize -e "reverb:room_size=0.4,mix=0.2"
       torchfx preset save loud --from my_chain.toml
 
     """

--- a/src/cli/commands/process.py
+++ b/src/cli/commands/process.py
@@ -193,7 +193,7 @@ def process_cmd(
     \b
     Examples
     --------
-      torchfx process in.wav out.wav -e normalize -e "reverb:decay=0.6"
+      torchfx process in.wav out.wav -e normalize -e "reverb:room_size=0.6"
       torchfx process "*.wav" -O ./processed/ -e gain:0.5
       cat in.wav | torchfx process - - -e normalize | aplay
       torchfx process in.wav out.wav --config chain.toml

--- a/src/cli/commands/record.py
+++ b/src/cli/commands/record.py
@@ -50,7 +50,7 @@ def record_cmd(
     --------
       torchfx record out.wav --duration 10
       torchfx record out.wav -t 5 -r 48000 -C 2
-      torchfx record out.wav -t 10 -e normalize -e "reverb:decay=0.3"
+      torchfx record out.wav -t 10 -e normalize -e "reverb:room_size=0.3"
 
     """
     import torch

--- a/src/cli/commands/watch.py
+++ b/src/cli/commands/watch.py
@@ -52,7 +52,7 @@ def watch_cmd(
     \b
     Examples
     --------
-      torchfx watch ./input/ ./output/ -e normalize -e "reverb:decay=0.4"
+      torchfx watch ./input/ ./output/ -e normalize -e "reverb:room_size=0.4"
       torchfx watch ./bounces/ ./mastered/ --config master.toml
       torchfx watch ./raw/ ./processed/ --preset vocal-cleanup --recursive
 

--- a/src/cli/parsing.py
+++ b/src/cli/parsing.py
@@ -13,7 +13,7 @@ String format
 Examples::
 
     gain:0.5
-    reverb:decay=0.6,mix=0.3
+    reverb:room_size=0.6,mix=0.3
     normalize
     lowpass:cutoff=1000,order=4
     parametriceq:frequency=2000,q=1.5,gain=6,gain_scale=db
@@ -24,7 +24,7 @@ TOML configuration
 
     [[effects]]
     name = "reverb"
-    decay = 0.6
+    room_size = 0.6
     mix = 0.3
 
     [[effects]]
@@ -79,7 +79,7 @@ EFFECT_REGISTRY: dict[str, tuple[type[FX], list[str]]] = {
     # ── effects ──────────────────────────────────────────────
     "gain": (Gain, ["gain"]),
     "normalize": (Normalize, ["peak"]),
-    "reverb": (Reverb, ["delay", "decay", "mix"]),
+    "reverb": (Reverb, ["room_size", "damping", "mix"]),
     "delay": (Delay, ["delay_samples", "feedback", "mix"]),
     # ── biquad filters ──────────────────────────────────────
     "lowpass": (BiquadLPF, ["cutoff", "q"]),
@@ -251,7 +251,7 @@ def load_effects_from_config(path: str | Path) -> list[FX]:
 
         [[effects]]
         name = "reverb"
-        decay = 0.6
+        room_size = 0.6
         mix = 0.3
 
         [[effects]]

--- a/src/cli/repl.py
+++ b/src/cli/repl.py
@@ -67,7 +67,7 @@ _HELP_TEXT = """\
 [bold cyan]TorchFX Interactive REPL[/bold cyan]
 
   [green]load[/green] <file>                     Load an audio file
-  [green]add[/green] <effect-spec>               Add an effect (e.g. reverb:decay=0.5)
+  [green]add[/green] <effect-spec>               Add an effect (e.g. reverb:room_size=0.5)
   [green]remove[/green] <index>                  Remove effect at index (1-based)
   [green]list[/green]                            Show current effect chain
   [green]effects[/green]                         List all available effects

--- a/src/torchfx/_csrc/binding.cpp
+++ b/src/torchfx/_csrc/binding.cpp
@@ -6,6 +6,7 @@
 #include "torchfx/compressor_kernel.h"
 #include "torchfx/expander_kernel.h"
 #include "torchfx/limiter_kernel.h"
+#include "torchfx/reverb_kernel.h"
 #endif
 
 // CPU implementation declarations
@@ -57,6 +58,16 @@ torch::Tensor limiter_forward_cpu(
     double threshold_lin,
     double attack_coeff,
     double release_coeff);
+
+torch::Tensor reverb_forward_cpu(
+    const torch::Tensor& x,
+    int fs,
+    double feedback,
+    double damp,
+    double input_gain,
+    double allpass_fb,
+    double wet,
+    double dry);
 
 // Dispatch: select CUDA or CPU implementation based on tensor device.
 // `threshold` is the sequential-vs-parallel-scan boundary used by the CUDA path
@@ -188,6 +199,27 @@ torch::Tensor limiter_forward(
   return limiter_forward_cpu(x, peak_env, threshold_lin, attack_coeff, release_coeff);
 }
 
+// Freeverb-style reverb dispatch. Comb/all-pass tunings scale with `fs`; `feedback`,
+// `damp`, `wet`, `dry` come from the Python layer's room-size/damping/mix parameters.
+torch::Tensor reverb_forward(
+    const torch::Tensor& x,
+    int fs,
+    double feedback,
+    double damp,
+    double input_gain,
+    double allpass_fb,
+    double wet,
+    double dry) {
+#ifdef WITH_CUDA
+  if (x.is_cuda()) {
+    return torchfx::reverb_forward_cuda(x, fs, feedback, damp, input_gain, allpass_fb, wet, dry);
+  }
+#else
+  TORCH_CHECK(!x.is_cuda(), "CUDA extension not compiled; move tensors to CPU");
+#endif
+  return reverb_forward_cpu(x, fs, feedback, damp, input_gain, allpass_fb, wet, dry);
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("biquad_forward", &biquad_forward,
         "Biquad filter forward (CUDA/CPU)",
@@ -215,4 +247,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         "Look-ahead brick-wall limiter forward (CUDA/CPU)",
         py::arg("x"), py::arg("peak_env"), py::arg("threshold_lin"),
         py::arg("attack_coeff"), py::arg("release_coeff"));
+  m.def("reverb_forward", &reverb_forward,
+        "Freeverb-style reverb forward (CUDA/CPU)",
+        py::arg("x"), py::arg("fs"), py::arg("feedback"), py::arg("damp"),
+        py::arg("input_gain"), py::arg("allpass_fb"), py::arg("wet"), py::arg("dry"));
 }

--- a/src/torchfx/_csrc/cpu/reverb_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/reverb_cpu.cpp
@@ -1,0 +1,147 @@
+#include <torch/torch.h>
+#include <algorithm>
+#include <cmath>
+#include "torchfx/reverb_kernel.h"
+
+// CPU Freeverb-style reverb. One channel per OpenMP thread; ring buffers live in a
+// zero-initialised scratch block per channel. See include/torchfx/reverb_kernel.h.
+
+#if defined(_MSC_VER)
+#define TORCHFX_RESTRICT __restrict
+#else
+#define TORCHFX_RESTRICT __restrict__
+#endif
+
+namespace {
+
+void reverb_dims(int fs, int* comb_len, int* comb_off, int* ap_len, int* ap_off,
+                 int& comb_total, int& total) {
+  comb_total = 0;
+  for (int i = 0; i < torchfx::kReverbNumCombs; ++i) {
+    const int len = std::max<int>(
+        1, static_cast<int>(std::lround(torchfx::kReverbCombTuning[i] * fs / torchfx::kReverbTuningFs)));
+    comb_len[i] = len;
+    comb_off[i] = comb_total;
+    comb_total += len;
+  }
+  int ap_total = 0;
+  for (int j = 0; j < torchfx::kReverbNumAllpass; ++j) {
+    const int len = std::max<int>(
+        1, static_cast<int>(std::lround(torchfx::kReverbAllpassTuning[j] * fs / torchfx::kReverbTuningFs)));
+    ap_len[j] = len;
+    ap_off[j] = ap_total;
+    ap_total += len;
+  }
+  total = comb_total + ap_total;
+}
+
+template <typename scalar_t>
+void reverb_loop(
+    const scalar_t* TORCHFX_RESTRICT in_ptr,
+    scalar_t* TORCHFX_RESTRICT out_ptr,
+    scalar_t* TORCHFX_RESTRICT scratch,
+    int64_t C,
+    int64_t T,
+    const int* comb_len,
+    const int* comb_off,
+    const int* ap_len,
+    const int* ap_off,
+    int comb_total,
+    int total,
+    scalar_t feedback,
+    scalar_t damp,
+    scalar_t input_gain,
+    scalar_t allpass_fb,
+    scalar_t wet,
+    scalar_t dry) {
+
+  const scalar_t one = static_cast<scalar_t>(1);
+
+  #pragma omp parallel for schedule(static) if (C > 1)
+  for (int64_t c = 0; c < C; ++c) {
+    const scalar_t* in_c = in_ptr + c * T;
+    scalar_t* out_c = out_ptr + c * T;
+    scalar_t* buf = scratch + c * total;
+
+    scalar_t fstore[torchfx::kReverbNumCombs];
+    int cidx[torchfx::kReverbNumCombs];
+    int aidx[torchfx::kReverbNumAllpass];
+    for (int i = 0; i < torchfx::kReverbNumCombs; ++i) {
+      fstore[i] = 0;
+      cidx[i] = 0;
+    }
+    for (int j = 0; j < torchfx::kReverbNumAllpass; ++j) aidx[j] = 0;
+
+    for (int64_t n = 0; n < T; ++n) {
+      const scalar_t xn = in_c[n];
+      const scalar_t inp = xn * input_gain;
+      scalar_t acc = 0;
+
+      for (int i = 0; i < torchfx::kReverbNumCombs; ++i) {
+        scalar_t* cb = buf + comb_off[i];
+        const scalar_t bo = cb[cidx[i]];
+        fstore[i] = bo * (one - damp) + fstore[i] * damp;
+        cb[cidx[i]] = inp + fstore[i] * feedback;
+        if (++cidx[i] >= comb_len[i]) cidx[i] = 0;
+        acc += bo;
+      }
+      for (int j = 0; j < torchfx::kReverbNumAllpass; ++j) {
+        scalar_t* ab = buf + comb_total + ap_off[j];
+        const scalar_t bo = ab[aidx[j]];
+        ab[aidx[j]] = acc + bo * allpass_fb;
+        acc = bo - acc;
+        if (++aidx[j] >= ap_len[j]) aidx[j] = 0;
+      }
+      out_c[n] = xn * dry + acc * wet;
+    }
+  }
+}
+
+}  // namespace
+
+torch::Tensor reverb_forward_cpu(
+    const torch::Tensor& x,
+    int fs,
+    double feedback,
+    double damp,
+    double input_gain,
+    double allpass_fb,
+    double wet,
+    double dry) {
+
+  TORCH_CHECK(!x.is_cuda(), "reverb_forward_cpu: input must be on CPU");
+
+  auto x_cont = x.contiguous();
+  const int orig_dim = x_cont.dim();
+  if (orig_dim == 1) {
+    x_cont = x_cont.unsqueeze(0);
+  }
+  const int64_t C = x_cont.size(0);
+  const int64_t T = x_cont.size(1);
+
+  int comb_len[torchfx::kReverbNumCombs], comb_off[torchfx::kReverbNumCombs];
+  int ap_len[torchfx::kReverbNumAllpass], ap_off[torchfx::kReverbNumAllpass];
+  int comb_total, total;
+  reverb_dims(fs, comb_len, comb_off, ap_len, ap_off, comb_total, total);
+
+  auto output = torch::empty_like(x_cont);
+  auto scratch = torch::zeros({C, static_cast<int64_t>(total)}, x_cont.options());
+
+  if (x_cont.dtype() == torch::kFloat32) {
+    reverb_loop<float>(
+        x_cont.data_ptr<float>(), output.data_ptr<float>(), scratch.data_ptr<float>(),
+        C, T, comb_len, comb_off, ap_len, ap_off, comb_total, total,
+        static_cast<float>(feedback), static_cast<float>(damp), static_cast<float>(input_gain),
+        static_cast<float>(allpass_fb), static_cast<float>(wet), static_cast<float>(dry));
+  } else {
+    reverb_loop<double>(
+        x_cont.data_ptr<double>(), output.data_ptr<double>(), scratch.data_ptr<double>(),
+        C, T, comb_len, comb_off, ap_len, ap_off, comb_total, total,
+        feedback, damp, input_gain, allpass_fb, wet, dry);
+  }
+
+  if (orig_dim == 1) {
+    return output.squeeze(0);
+  }
+  return output;
+}

--- a/src/torchfx/_csrc/cuda/reverb_forward.cu
+++ b/src/torchfx/_csrc/cuda/reverb_forward.cu
@@ -1,0 +1,147 @@
+#include <torch/torch.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <c10/cuda/CUDAStream.h>
+#include <algorithm>
+#include <cmath>
+#include "torchfx/reverb_kernel.h"
+
+// Freeverb-style reverb, one thread per channel (sequential over time, ring buffers in a
+// per-channel scratch block). Templated on scalar_t so float32 runs natively in FP32. See
+// reverb_kernel.h for the math.
+
+namespace torchfx {
+
+struct ReverbDims {
+  int comb_len[kReverbNumCombs];
+  int comb_off[kReverbNumCombs];
+  int ap_len[kReverbNumAllpass];
+  int ap_off[kReverbNumAllpass];
+  int comb_total;
+  int total;
+};
+
+template <typename scalar_t>
+__global__ void reverb_kernel(
+    const scalar_t* __restrict__ input,
+    scalar_t* __restrict__ output,
+    scalar_t* __restrict__ scratch,
+    int C,
+    int T,
+    ReverbDims dims,
+    scalar_t feedback,
+    scalar_t damp,
+    scalar_t input_gain,
+    scalar_t allpass_fb,
+    scalar_t wet,
+    scalar_t dry) {
+
+  const int c = blockIdx.x * blockDim.x + threadIdx.x;
+  if (c >= C) return;
+
+  const scalar_t one = static_cast<scalar_t>(1);
+  const scalar_t* in_c = input + static_cast<int64_t>(c) * T;
+  scalar_t* out_c = output + static_cast<int64_t>(c) * T;
+  scalar_t* buf = scratch + static_cast<int64_t>(c) * dims.total;
+
+  scalar_t fstore[kReverbNumCombs];
+  int cidx[kReverbNumCombs];
+  int aidx[kReverbNumAllpass];
+#pragma unroll
+  for (int i = 0; i < kReverbNumCombs; ++i) {
+    fstore[i] = 0;
+    cidx[i] = 0;
+  }
+#pragma unroll
+  for (int j = 0; j < kReverbNumAllpass; ++j) aidx[j] = 0;
+
+  for (int n = 0; n < T; ++n) {
+    const scalar_t xn = in_c[n];
+    const scalar_t inp = xn * input_gain;
+    scalar_t acc = 0;
+
+#pragma unroll
+    for (int i = 0; i < kReverbNumCombs; ++i) {
+      scalar_t* cb = buf + dims.comb_off[i];
+      const scalar_t bo = cb[cidx[i]];
+      fstore[i] = bo * (one - damp) + fstore[i] * damp;
+      cb[cidx[i]] = inp + fstore[i] * feedback;
+      if (++cidx[i] >= dims.comb_len[i]) cidx[i] = 0;
+      acc += bo;
+    }
+#pragma unroll
+    for (int j = 0; j < kReverbNumAllpass; ++j) {
+      scalar_t* ab = buf + dims.comb_total + dims.ap_off[j];
+      const scalar_t bo = ab[aidx[j]];
+      ab[aidx[j]] = acc + bo * allpass_fb;
+      acc = bo - acc;
+      if (++aidx[j] >= dims.ap_len[j]) aidx[j] = 0;
+    }
+    out_c[n] = xn * dry + acc * wet;
+  }
+}
+
+torch::Tensor reverb_forward_cuda(
+    const torch::Tensor& x,
+    int fs,
+    double feedback,
+    double damp,
+    double input_gain,
+    double allpass_fb,
+    double wet,
+    double dry) {
+
+  TORCH_CHECK(x.is_cuda(), "reverb_forward_cuda: input must be on CUDA");
+
+  auto x_cont = x.contiguous();
+  int64_t C, T;
+  if (x_cont.dim() == 1) {
+    C = 1;
+    T = x_cont.size(0);
+    x_cont = x_cont.unsqueeze(0);
+  } else {
+    C = x_cont.size(0);
+    T = x_cont.size(1);
+  }
+
+  ReverbDims dims;
+  dims.comb_total = 0;
+  for (int i = 0; i < kReverbNumCombs; ++i) {
+    const int len =
+        std::max<int>(1, static_cast<int>(std::lround(kReverbCombTuning[i] * fs / kReverbTuningFs)));
+    dims.comb_len[i] = len;
+    dims.comb_off[i] = dims.comb_total;
+    dims.comb_total += len;
+  }
+  int ap_total = 0;
+  for (int j = 0; j < kReverbNumAllpass; ++j) {
+    const int len = std::max<int>(
+        1, static_cast<int>(std::lround(kReverbAllpassTuning[j] * fs / kReverbTuningFs)));
+    dims.ap_len[j] = len;
+    dims.ap_off[j] = ap_total;
+    ap_total += len;
+  }
+  dims.total = dims.comb_total + ap_total;
+
+  auto output = torch::empty_like(x_cont);
+  auto scratch = torch::zeros({C, static_cast<int64_t>(dims.total)}, x_cont.options());
+
+  const int threads = 128;
+  const int blocks = (static_cast<int>(C) + threads - 1) / threads;
+  const auto stream = c10::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_FLOATING_TYPES(x_cont.scalar_type(), "reverb_forward_cuda", [&] {
+    reverb_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+        x_cont.data_ptr<scalar_t>(), output.data_ptr<scalar_t>(), scratch.data_ptr<scalar_t>(),
+        static_cast<int>(C), static_cast<int>(T), dims, static_cast<scalar_t>(feedback),
+        static_cast<scalar_t>(damp), static_cast<scalar_t>(input_gain),
+        static_cast<scalar_t>(allpass_fb), static_cast<scalar_t>(wet), static_cast<scalar_t>(dry));
+  });
+
+  if (x.dim() == 1) {
+    return output.squeeze(0);
+  }
+  return output;
+}
+
+}  // namespace torchfx

--- a/src/torchfx/_csrc/include/torchfx/reverb_kernel.h
+++ b/src/torchfx/_csrc/include/torchfx/reverb_kernel.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <torch/types.h>
+
+namespace torchfx {
+
+// Freeverb-style algorithmic reverb: per channel, 8 parallel low-pass-feedback comb
+// filters summed, then fed through 4 series all-pass diffusers, mixed wet/dry.
+//
+// Comb (i):  out = buf[idx]; store = out*(1-damp) + store*damp;
+//            buf[idx] = in*input_gain + store*feedback;  acc += out
+// Allpass(j): bo = buf[idx]; buf[idx] = acc + bo*allpass_fb;  acc = bo - acc
+// y[n] = x[n]*dry + acc*wet
+//
+// The classic Schroeder/Moorer comb tunings (at 44.1 kHz) scaled to the signal's `fs`;
+// ring buffers live in a zero-initialised scratch tensor, one contiguous block per
+// channel. State is per-call (not carried across forward() calls).
+
+// Comb / all-pass delay tunings in samples at 44.1 kHz (Freeverb defaults).
+constexpr int kReverbNumCombs = 8;
+constexpr int kReverbNumAllpass = 4;
+constexpr int kReverbCombTuning[kReverbNumCombs] = {1116, 1188, 1277, 1356,
+                                                    1422, 1491, 1557, 1617};
+constexpr int kReverbAllpassTuning[kReverbNumAllpass] = {556, 441, 341, 225};
+constexpr double kReverbTuningFs = 44100.0;
+
+torch::Tensor reverb_forward_cuda(
+    const torch::Tensor& x,
+    int fs,
+    double feedback,
+    double damp,
+    double input_gain,
+    double allpass_fb,
+    double wet,
+    double dry);
+
+}  // namespace torchfx

--- a/src/torchfx/_ops.py
+++ b/src/torchfx/_ops.py
@@ -446,3 +446,49 @@ def limiter_forward(
     if len(original_shape) == 2:
         return result_2d
     return result_2d.reshape(original_shape)
+
+
+def reverb_forward(
+    x: Tensor,
+    fs: int,
+    feedback: float,
+    damp: float,
+    input_gain: float,
+    allpass_fb: float,
+    wet: float,
+    dry: float,
+) -> Tensor:
+    """Dispatch the Freeverb-style reverb to the native kernel (CUDA or CPU).
+
+    Eight parallel low-pass-feedback comb filters and four series all-pass diffusers per
+    channel, with comb/all-pass tunings scaled to ``fs``. ``feedback`` and ``damp`` set the
+    decay length and high-frequency damping; ``wet``/``dry`` mix the result. Returns the
+    processed tensor with the input shape and dtype preserved.
+
+    """
+    if x.ndim < 1:
+        raise ValueError("Input tensor must have at least 1 dimension.")
+    if not x.is_floating_point():
+        raise TypeError("Input tensor must use a floating-point dtype.")
+
+    original_shape = x.shape
+    if x.ndim == 1:
+        x_2d = x.unsqueeze(0)
+    elif x.ndim == 2:
+        x_2d = x
+    else:
+        x_2d = x.reshape(-1, x.size(-1))
+
+    native_dtype = torch.float64 if x_2d.dtype == torch.float64 else torch.float32
+    x_native = x_2d if x_2d.dtype == native_dtype else x_2d.to(dtype=native_dtype)
+
+    result_native: Tensor = _ext.reverb_forward(
+        x_native, int(fs), feedback, damp, input_gain, allpass_fb, wet, dry
+    )
+    result_2d = result_native if result_native.dtype == x.dtype else result_native.to(dtype=x.dtype)
+
+    if len(original_shape) == 1:
+        return result_2d.squeeze(0)
+    if len(original_shape) == 2:
+        return result_2d
+    return result_2d.reshape(original_shape)

--- a/src/torchfx/effect.py
+++ b/src/torchfx/effect.py
@@ -812,148 +812,118 @@ class PerChannelNormalizationStrategy(NormalizationStrategy):
 
 
 class Reverb(FX):
-    r"""Apply reverb effect using a feedback delay network for spatial ambiance.
+    r"""Freeverb-style algorithmic reverb (parallel combs + series all-passes).
 
-    The Reverb effect creates spatial ambiance by simulating sound reflections
-    in an acoustic space. It uses a simple feedback comb filter (feedback delay
-    network) to produce reverb-like effects with controllable decay time and
-    wet/dry mix.
-
-    This is a basic reverb implementation suitable for adding spatial depth to
-    audio signals. For more complex reverb algorithms, consider using convolution
-    reverbs with impulse responses.
+    Replaces the original single-comb reverb with the classic Schroeder/Moorer structure:
+    per channel, **8 parallel low-pass-feedback comb filters** are summed and fed through
+    **4 series all-pass diffusers**, producing a dense, natural decay. The comb/all-pass
+    delay tunings scale with the sampling rate so the character is consistent across
+    ``fs``. The network runs in a native per-channel C++/CUDA kernel.
 
     Parameters
     ----------
-    delay : int, optional
-        Delay time in samples for the feedback comb filter. Determines the
-        apparent size of the simulated space. Default is 4410 samples, which
-        corresponds to approximately 100ms at 44.1kHz sample rate.
-    decay : float, optional
-        Feedback decay factor controlling how quickly the reverb tail fades.
-        Must be in the range (0, 1). Higher values create longer reverb tails.
-        Default is 0.5.
-    mix : float, optional
-        Wet/dry mix controlling the balance between processed (wet) and
-        original (dry) signals. Range is [0, 1] where:
+    room_size : float, default=0.5
+        Apparent room size in ``[0, 1]`` — sets the comb feedback (decay length). Larger
+        values give a longer reverb tail.
+    damping : float, default=0.5
+        High-frequency damping in ``[0, 1]``. Larger values absorb highs faster, for a
+        warmer/darker tail.
+    mix : float, default=0.3
+        Wet/dry balance in ``[0, 1]`` (``0`` = dry, ``1`` = fully wet).
+    fs : int or None, default=None
+        Sampling rate in Hz, used to scale the delay tunings. May be left ``None`` and
+        supplied lazily by a ``Wave`` pipeline (``wave | reverb``).
 
-        - 0.0 = fully dry (no reverb)
-        - 1.0 = fully wet (only reverb)
-        - 0.5 = equal mix
-
-        Default is 0.5.
+    Returns
+    -------
+    Tensor
+        The reverberated waveform, same shape and dtype as the input.
 
     Raises
     ------
-    AssertionError
-        If delay is not positive, decay is not in (0, 1), or mix is not in [0, 1].
+    ValueError
+        If ``room_size``/``damping``/``mix`` are outside ``[0, 1]``, ``fs`` is
+        non-positive, or ``forward`` is called before ``fs`` is known.
 
     See Also
     --------
-    Delay : Multi-tap delay effect with BPM synchronization
-    Gain : Volume adjustment effect
+    Delay : Multi-tap delay effect with BPM synchronisation.
 
     Notes
     -----
-    **Algorithm:**
-
-    The reverb is computed using a feedback comb filter:
-
-    .. math::
-
-        y[n] = (1 - mix) \cdot x[n] + mix \cdot (x[n] + decay \cdot x[n - delay])
-
-    where:
-        - :math:`x[n]` is the input signal
-        - :math:`y[n]` is the output signal
-        - :math:`delay` is the delay time in samples
-        - :math:`decay` is the feedback decay factor
-        - :math:`mix` is the wet/dry mix parameter
-
-    **Processing Details:**
-
-    - If the input waveform is shorter than the delay time, the input is returned
-      unchanged.
-    - The effect processes tensors of arbitrary shape (..., time).
-    - Uses @torch.no_grad() decorator for efficient inference-only operation.
-    - Padding is applied using torch.nn.functional.pad for the delay buffer.
-
-    **Delay Time Calculation:**
-
-    To convert time in milliseconds to samples:
-
-    .. math::
-
-        delay_{samples} = \frac{time_{ms}}{1000} \cdot sample\_rate
-
-    For example, at 44.1kHz:
-        - 50ms = 2205 samples
-        - 100ms = 4410 samples (default)
-        - 200ms = 8820 samples
+    Each channel is processed independently with identical tunings (no stereo-width spread
+    — a possible follow-up). State is reset per ``forward`` call, so block-wise streaming
+    is not state-continuous across chunks. This is a **breaking change** from the pre-0.7
+    ``Reverb(delay, decay, mix)`` API.
 
     Examples
     --------
-    Basic reverb with default parameters:
+    >>> import torch
+    >>> from torchfx.effect import Reverb
+    >>> x = torch.randn(2, 48000)
+    >>> y = Reverb(room_size=0.7, damping=0.4, mix=0.3, fs=48000)(x)
+    >>> y.shape
+    torch.Size([2, 48000])
+
+    In a ``Wave`` pipeline (``fs`` supplied automatically):
 
     >>> import torchfx as fx
-    >>> wave = fx.Wave.from_file("audio.wav")
-    >>> reverb = fx.Reverb()
-    >>> processed = wave | reverb
-
-    Short room reverb (50ms delay):
-
-    >>> reverb = fx.Reverb(delay=2205, decay=0.4, mix=0.3)
-    >>> processed = wave | reverb
-
-    Long hall reverb (200ms delay):
-
-    >>> reverb = fx.Reverb(delay=8820, decay=0.7, mix=0.4)
-    >>> processed = wave | reverb
-
-    Subtle reverb with low mix:
-
-    >>> reverb = fx.Reverb(delay=4410, decay=0.5, mix=0.2)
-    >>> processed = wave | reverb
-
-    Direct tensor processing:
-
-    >>> import torch
-    >>> waveform = torch.randn(2, 44100)  # (channels, samples)
-    >>> reverb = fx.Reverb(delay=4410, decay=0.6, mix=0.3)
-    >>> reverberated = reverb(waveform)
-
-    Chain with other effects:
-
-    >>> processed = wave | fx.Gain(0.8) | fx.Reverb(delay=4410, decay=0.5, mix=0.3)
-
-    GPU processing:
-
-    >>> wave = wave.to("cuda")
-    >>> reverb = fx.Reverb(delay=4410, decay=0.6, mix=0.3).to("cuda")
-    >>> processed = wave | reverb
+    >>> processed = wave | fx.Reverb(room_size=0.8, mix=0.25)  # doctest: +SKIP
 
     """
 
-    def __init__(self, delay: int = 4410, decay: float = 0.5, mix: float = 0.5) -> None:
-        super().__init__()
-        assert delay > 0, "Delay must be positive."
-        assert 0 < decay < 1, "Decay must be between 0 and 1."
-        assert 0 <= mix <= 1, "Mix must be between 0 and 1."
+    # Freeverb fixed constants (input gain into the comb bank; all-pass feedback).
+    _INPUT_GAIN = 0.015
+    _ALLPASS_FB = 0.5
 
-        self.delay = delay
-        self.decay = decay
-        self.mix = mix
+    def __init__(
+        self,
+        room_size: float = 0.5,
+        damping: float = 0.5,
+        mix: float = 0.3,
+        fs: int | None = None,
+    ) -> None:
+        super().__init__()
+        if not 0 <= room_size <= 1:
+            raise ValueError(f"room_size must be in [0, 1], got {room_size}.")
+        if not 0 <= damping <= 1:
+            raise ValueError(f"damping must be in [0, 1], got {damping}.")
+        if not 0 <= mix <= 1:
+            raise ValueError(f"mix must be in [0, 1], got {mix}.")
+        if fs is not None and fs <= 0:
+            raise ValueError(f"Sample rate (fs) must be positive, got {fs}.")
+
+        self.room_size = float(room_size)
+        self.damping = float(damping)
+        self.mix = float(mix)
+        self.fs = fs
 
     @override
     @torch.no_grad()
     def forward(self, waveform: Tensor) -> Tensor:
-        # waveform: (..., time)
-        if waveform.size(-1) <= self.delay:
-            return waveform
+        if self.fs is None:
+            raise ValueError(
+                "Sample rate (fs) is required for the reverb. Use it in a Wave "
+                "pipeline (wave | reverb) or pass fs at construction."
+            )
+        if self.fs <= 0:
+            raise ValueError("Sample rate (fs) must be positive.")
 
-        from torchfx._ops import delay_line_forward
+        from torchfx._ops import reverb_forward
 
-        return delay_line_forward(waveform, self.delay, self.decay, self.mix)
+        # Freeverb parameter mapping: room_size -> comb feedback, damping -> LP coefficient.
+        feedback = self.room_size * 0.28 + 0.7
+        damp = self.damping * 0.4
+        return reverb_forward(
+            waveform,
+            self.fs,
+            feedback,
+            damp,
+            self._INPUT_GAIN,
+            self._ALLPASS_FB,
+            self.mix,  # wet
+            1.0 - self.mix,  # dry
+        )
 
 
 class DelayStrategy(abc.ABC):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,11 +99,11 @@ class TestParseEffectString:
         assert fx.gain == pytest.approx(0.5)
 
     def test_keyword_params(self) -> None:
-        fx = parse_effect_string("reverb:decay=0.6,mix=0.3")
+        fx = parse_effect_string("reverb:room_size=0.6,mix=0.3")
         from torchfx.effect import Reverb
 
         assert isinstance(fx, Reverb)
-        assert fx.decay == pytest.approx(0.6)
+        assert fx.room_size == pytest.approx(0.6)
         assert fx.mix == pytest.approx(0.3)
 
     def test_mixed_positional_and_keyword(self) -> None:

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -15,7 +15,6 @@ from torchfx.effect import (
     PercentileNormalizationStrategy,
     PerChannelNormalizationStrategy,
     PingPongDelayStrategy,
-    Reverb,
     RMSNormalizationStrategy,
 )
 
@@ -200,93 +199,7 @@ def test_per_channel_normalization_strategy_zero():
     torch.testing.assert_close(out, waveform)
 
 
-def test_reverb_basic():
-    # Simple waveform, delay=2, decay=0.5, mix=1.0 (fully wet)
-    waveform = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
-    reverb = Reverb(delay=2, decay=0.5, mix=1.0)
-    # Expected: y[n] = x[n] + 0.5 * x[n-2] for n >= 2, else x[n]
-    expected = torch.tensor(
-        [
-            1.0,  # n=0: no delay
-            2.0,  # n=1: no delay
-            3.0 + 0.5 * 1.0,  # n=2
-            4.0 + 0.5 * 2.0,  # n=3
-            5.0 + 0.5 * 3.0,  # n=4
-        ]
-    )
-    out = reverb(waveform)
-    torch.testing.assert_close(out, expected)
-
-
-def test_reverb_mix_zero():
-    # mix=0 should return the original waveform
-    waveform = torch.randn(10)
-    reverb = Reverb(delay=3, decay=0.7, mix=0.0)
-    out = reverb(waveform)
-    torch.testing.assert_close(out, waveform)
-
-
-def test_reverb_short_waveform():
-    # If waveform shorter than delay, should return unchanged
-    waveform = torch.tensor([1.0, 2.0])
-    reverb = Reverb(delay=3, decay=0.5, mix=1.0)
-    out = reverb(waveform)
-    torch.testing.assert_close(out, waveform)
-
-
-def test_reverb_multichannel():
-    # Test with 2D waveform (channels, time)
-    waveform = torch.tensor([[1.0, 2.0, 3.0, 4.0], [0.5, 1.5, 2.5, 3.5]])
-    reverb = Reverb(delay=2, decay=0.5, mix=1.0)
-    expected = torch.empty_like(waveform)
-    # Channel 0
-    expected[0, 0] = 1.0
-    expected[0, 1] = 2.0
-    expected[0, 2] = 3.0 + 0.5 * 1.0
-    expected[0, 3] = 4.0 + 0.5 * 2.0
-    # Channel 1
-    expected[1, 0] = 0.5
-    expected[1, 1] = 1.5
-    expected[1, 2] = 2.5 + 0.5 * 0.5
-    expected[1, 3] = 3.5 + 0.5 * 1.5
-    out = reverb(waveform)
-    torch.testing.assert_close(out, expected)
-
-
-def test_reverb_batched_3d_input():
-    waveform = torch.randn(2, 3, 128)
-    reverb = Reverb(delay=4, decay=0.4, mix=0.5)
-    out = reverb(waveform)
-
-    assert out.shape == waveform.shape
-    assert torch.isfinite(out).all()
-
-
-def test_reverb_float16_input_supported():
-    waveform = torch.randn(1, 64, dtype=torch.float16)
-    reverb = Reverb(delay=3, decay=0.2, mix=0.5)
-    out = reverb(waveform)
-
-    assert out.dtype == torch.float16
-    assert out.shape == waveform.shape
-
-
-@pytest.mark.parametrize("delay", [0, -1])
-def test_reverb_invalid_delay(delay):
-    with pytest.raises(AssertionError):
-        Reverb(delay=delay, decay=0.5, mix=0.5)
-
-
-@pytest.mark.parametrize("decay", [0.0, 1.0, -0.1, 1.1])
-def test_reverb_invalid_decay(decay):
-    with pytest.raises(AssertionError):
-        Reverb(delay=2, decay=decay, mix=0.5)
-
-
-@pytest.mark.parametrize("mix", [-0.1, 1.1])
-def test_reverb_invalid_mix(mix):
-    with pytest.raises(AssertionError):
-        Reverb(delay=2, decay=0.5, mix=mix)
+# Reverb tests live in tests/test_reverb.py (Freeverb-style, issue #18).
 
 
 # Delay tests

--- a/tests/test_reverb.py
+++ b/tests/test_reverb.py
@@ -1,0 +1,118 @@
+"""Tests for the Freeverb-style Reverb effect (issue #18)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from torchfx.effect import Reverb
+
+FS = 48000
+
+
+def _impulse(n: int = FS, c: int = 1, dtype=torch.float64) -> torch.Tensor:
+    x = torch.zeros(c, n, dtype=dtype)
+    x[:, 0] = 1.0
+    return x
+
+
+# --------------------------------------------------------------------------- #
+# Stability + reverb tail
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("room", [0.0, 0.5, 0.95])
+@pytest.mark.parametrize("damp", [0.0, 0.5, 1.0])
+def test_stable_and_finite(room, damp):
+    rev = Reverb(room_size=room, damping=damp, mix=1.0, fs=FS)
+    y = rev(_impulse())
+    assert torch.isfinite(y).all()
+    assert y.abs().max() < 10.0  # bounded (no runaway feedback)
+
+
+def test_impulse_produces_decaying_tail():
+    rev = Reverb(room_size=0.85, damping=0.3, mix=1.0, fs=FS)
+    y = rev(_impulse())[0]
+    assert (y[2000:] ** 2).sum() > 0  # there is a tail
+    assert y[40000:].abs().max() < y[:4000].abs().max()  # and it decays
+
+
+def test_larger_room_has_longer_tail():
+    small = Reverb(room_size=0.2, damping=0.2, mix=1.0, fs=FS)(_impulse())[0]
+    large = Reverb(room_size=0.95, damping=0.2, mix=1.0, fs=FS)(_impulse())[0]
+    # Energy in the late tail grows with room size (longer decay).
+    assert (large[24000:] ** 2).sum() > (small[24000:] ** 2).sum()
+
+
+def test_damping_changes_output():
+    bright = Reverb(room_size=0.8, damping=0.0, mix=1.0, fs=FS)(_impulse())
+    dark = Reverb(room_size=0.8, damping=1.0, mix=1.0, fs=FS)(_impulse())
+    assert not torch.allclose(bright, dark)
+
+
+# --------------------------------------------------------------------------- #
+# Wet/dry mix
+# --------------------------------------------------------------------------- #
+def test_mix_zero_is_dry():
+    x = torch.randn(2, 8000, dtype=torch.float64)
+    torch.testing.assert_close(Reverb(mix=0.0, fs=FS)(x), x, rtol=1e-12, atol=1e-13)
+
+
+def test_mix_interpolates_linearly():
+    x = _impulse(n=8000)
+    full = Reverb(room_size=0.8, mix=1.0, fs=FS)(x)
+    half = Reverb(room_size=0.8, mix=0.5, fs=FS)(x)
+    expected_half = 0.5 * x + 0.5 * full  # dry=1-mix, wet=mix on the same wet signal
+    torch.testing.assert_close(half, expected_half, rtol=1e-9, atol=1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# Shapes, dtypes, channels
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("shape", [(8000,), (2, 8000), (3, 2, 8000)])
+def test_shapes_preserved(shape):
+    y = Reverb(fs=FS)(torch.randn(*shape, dtype=torch.float64))
+    assert y.shape == shape
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_dtype_preserved(dtype):
+    y = Reverb(fs=FS)(torch.randn(2, 8000, dtype=dtype))
+    assert y.dtype == dtype
+
+
+def test_identical_channels_identical_output():
+    mono = _impulse(n=8000)
+    y = Reverb(room_size=0.8, fs=FS)(mono.repeat(2, 1))
+    torch.testing.assert_close(y[0], y[1])
+
+
+# --------------------------------------------------------------------------- #
+# Lazy fs + validation
+# --------------------------------------------------------------------------- #
+def test_fs_required():
+    with pytest.raises(ValueError, match="Sample rate"):
+        Reverb()(torch.randn(1, 1000))
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"room_size": -0.1}, {"room_size": 1.1}, {"damping": 2.0}, {"mix": -1.0}, {"fs": 0}],
+)
+def test_invalid_params_raise(kwargs):
+    with pytest.raises(ValueError):
+        Reverb(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# CPU / CUDA parity
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_cpu_cuda_parity(dtype):
+    rev_cpu = Reverb(room_size=0.8, damping=0.4, mix=0.3, fs=FS)
+    rev_cuda = Reverb(room_size=0.8, damping=0.4, mix=0.3, fs=FS)
+    gen = torch.Generator().manual_seed(5)
+    x = torch.randn(4, 16000, generator=gen, dtype=dtype)
+    y_cpu = rev_cpu(x)
+    y_cuda = rev_cuda(x.cuda()).cpu()
+    tol = {"rtol": 2e-3, "atol": 2e-4} if dtype == torch.float32 else {"rtol": 1e-9, "atol": 1e-10}
+    torch.testing.assert_close(y_cpu, y_cuda, **tol)

--- a/uv.lock
+++ b/uv.lock
@@ -2737,7 +2737,7 @@ wheels = [
 
 [[package]]
 name = "torchfx"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-types" },


### PR DESCRIPTION
The last v0.7.0 feature plus the release bump.

## #18 — Freeverb-style reverb
Replaces the single feedforward-comb `Reverb` with the classic **Schroeder/Moorer** structure: per channel, **8 parallel low-pass-feedback comb filters** summed through **4 series all-pass diffusers**, in a native `reverb_forward` kernel (CPU OpenMP + CUDA, one channel per thread; ring buffers in a zero-init per-channel scratch block; comb/all-pass tunings scale with `fs`). MSVC-safe patterns.

**Breaking API:** `Reverb(room_size, damping, mix, fs)` (was `delay/decay/mix`) — `fs` is supplied by the `Wave` pipeline and scales the tunings. CLI `EFFECT_REGISTRY`/examples + the parse test updated; obsolete old-API tests removed.

**Validation:** `tests/test_reverb.py` (28) — stability across room/damp, decaying tail, room→tail-length, damping effect, wet/dry linearity, shapes/dtypes/channel independence, validation, **CPU↔CUDA parity** on an RTX 3070. Full suite **1368 (CPU) / 1456 (GPU)**.

## v0.7.0 release prep
- `pyproject` version **0.6.0 → 0.7.0** (uv.lock regenerated).
- CHANGELOG **`[Unreleased]` → `[0.7.0] - 2026-06-09`** (kept a fresh empty `[Unreleased]`).

**On merge to `master`**, `release.yml` tags `v0.7.0`, the wheel workflows publish to PyPI + the CUDA index, and a GitHub Release is created with the `[0.7.0]` notes (via the #29 extractor — verified it pulls the right section).

**v0.7.0 highlights:** Compressor/Expander/Gate/Limiter, Freeverb reverb, cache-blocked CPU SIMD, single-pass GPU SOS scan, batched multi-signal processing, perf-regression gates, release automation, Codecov.

Closes #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)