### PR TITLE
🚀 Release v0.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,15 @@ jobs:
       - name: Report coverage (enforces fail_under)
         run: uv run coverage report -m
 
+      - name: Generate XML report
+        run: uv run coverage xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Generate HTML report
         if: always()
         run: uv run coverage html -d htmlcov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,23 @@ jobs:
           git tag -a "$tag" -m "Release $tag"
           git push origin "$tag"
 
+      # Publish a GitHub Release whose notes are the CHANGELOG section for this
+      # version (tools/extract_changelog.py). Falls back to a placeholder if the
+      # CHANGELOG has no matching `## [X.Y.Z]` header yet.
+      - name: Create GitHub Release with CHANGELOG notes
+        if: steps.check.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="v${{ steps.ver.outputs.version }}"
+          if python tools/extract_changelog.py "${{ steps.ver.outputs.version }}" > release-notes.md; then
+            echo "Using the CHANGELOG section for ${{ steps.ver.outputs.version }}."
+          else
+            echo "::warning::No CHANGELOG section for ${{ steps.ver.outputs.version }}; using a placeholder."
+            printf 'Release %s. See the CHANGELOG for details.\n' "$tag" > release-notes.md
+          fi
+          gh release create "$tag" --title "$tag" --notes-file release-notes.md --verify-tag
+
       # Tag pushes from GITHUB_TOKEN do not retrigger workflows, so kick the
       # wheel builds off explicitly. Each runs with --ref pointing at the
       # new tag, so github.ref inside wheels.yml/wheels-cuda.yml is

--- a/.github/workflows/wheels-cuda.yml
+++ b/.github/workflows/wheels-cuda.yml
@@ -97,6 +97,19 @@ jobs:
         --exclude 'libnvJitLink.so*'
 
     steps:
+      # The CUDA wheel build installs the CUDA toolkit (dnf) plus a multi-GB CUDA
+      # torch wheel (pip) inside the manylinux container, whose writable layer lives
+      # on the runner's root filesystem. With the runner's default ~14 GB free that
+      # intermittently exhausts disk ("No space left on device"). Reclaim the
+      # preinstalled toolchains we don't use (~25 GB) first. See #74.
+      - name: Free up runner disk space
+        run: |
+          echo "disk before:"; df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
+                      /opt/hostedtoolcache /usr/local/share/boost /usr/lib/jvm \
+                      /usr/share/swift || true
+          echo "disk after:"; df -h /
+
       - uses: actions/checkout@v4
 
       - name: Build wheels

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,10 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   phase-3 recompute is gone. Measured on an RTX 3070, vs the 3-phase path:
   **5.9× fewer CUDA launches** (600 → 102 at K=50) and **~1.9× faster** fused
   cascades (K=50 18.9 → 9.9 ms); the fused launch count now sits **below** the
-  unfused baseline (102 vs 400). Opt-in via `TORCHFX_FUSED_SCAN=1` (the validated
-  3-phase path remains the default); equivalence to it and to `scipy.signal.sosfilt`
-  is gated by `tests/test_fused_scan_equivalence.py`, and the full suite passes
-  through the fused path.
+  unfused baseline (102 vs 400). This is now the **default** GPU path for SOS
+  cascades; set `TORCHFX_FUSED_SCAN=0` to force the legacy 3-phase oracle. Equivalence
+  to that oracle and to `scipy.signal.sosfilt` is gated by
+  `tests/test_fused_scan_equivalence.py`, and the full suite passes through the fused
+  path on both sm_86 (RTX 3070) and sm_89 (L40S); the decoupled look-back's forward
+  progress is validated across 46–142 SMs.
 
 ## [0.6.0] - 2026-06-04
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`torchfx.batch_process(waves, effect)` — batched multi-signal processing.** Applies an
+  effect to many `Wave` signals in a **single** native kernel launch by padding them to a
+  common length and concatenating on the channel dimension (the causal per-channel kernels
+  make this numerically identical to processing each signal separately). Fills the GPU and
+  amortises Python dispatch + OpenMP setup — **2.5–4.1× faster on CPU** for 8–512 stereo
+  files, more on GPU. For per-channel-independent effects (filters, `Gain`, dynamics);
+  see `benchmarks/bench_batch.py`. (Resolves #19.)
 - **`Limiter` — look-ahead brick-wall peak limiter.** Guarantees `|y| <= threshold` (a
   true brick wall) while staying transparent: a short `lookahead` reduces the gain
   *before* a peak (a vectorised forward max-pool computes the look-ahead window), the gain

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > The *Unreleased* section is for changes that are not yet released, but are going to be released in the next version.
 
+## [Unreleased]
+
+### Added
+
+- **Single-pass SOS scan (kernel-level fusion).** A new GPU path folds each cascade
+  section's forcing pass and the three-phase Blelloch scan into a **single
+  decoupled-look-back kernel** (Merrill–Garland / CUB style, with an atomic
+  per-section tile dispenser for deadlock-free forward progress), and folds the
+  per-section DF1 state update into one more kernel. Per fused section drops from
+  ~8 CUDA launches (forcing + 3 scan phases + 4 state copies) to **2**, and the
+  phase-3 recompute is gone. Measured on an RTX 3070, vs the 3-phase path:
+  **5.9× fewer CUDA launches** (600 → 102 at K=50) and **~1.9× faster** fused
+  cascades (K=50 18.9 → 9.9 ms); the fused launch count now sits **below** the
+  unfused baseline (102 vs 400). Opt-in via `TORCHFX_FUSED_SCAN=1` (the validated
+  3-phase path remains the default); equivalence to it and to `scipy.signal.sosfilt`
+  is gated by `tests/test_fused_scan_equivalence.py`, and the full suite passes
+  through the fused path.
+
 ## [0.6.0] - 2026-06-04
 
 ### Added

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`Limiter` — look-ahead brick-wall peak limiter.** Guarantees `|y| <= threshold` (a
+  true brick wall) while staying transparent: a short `lookahead` reduces the gain
+  *before* a peak (a vectorised forward max-pool computes the look-ahead window), the gain
+  is attack/release-smoothed toward that target, and a per-sample clamp enforces the
+  ceiling exactly. Unlike `Compressor(ratio=inf)` — a zero-look-ahead limiter that can
+  overshoot a single sample before its gain reacts — this never exceeds the ceiling.
+  Native `limiter_forward` kernel (CPU + CUDA, FP32/FP64). Usage:
+  `wave | Limiter(threshold=-1.0, lookahead=0.005)`. (Resolves #31.)
 - **`Expander` / `Gate` dynamics effects.** A downward expander — the mirror of the
   compressor, attenuating *below* the threshold — with `ratio`/`knee`/`attack`/`release`,
   an optional `floor` (range), and peak or RMS detection. `Gate` is the infinite-ratio

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Cache-blocked cross-channel CPU SIMD for SOS cascades.** When channels outnumber
+  CPU cores, the scalar per-channel kernel runs several channels serially on each core.
+  A new path packs a SIMD vector of channels: it transposes small `[W, B]` tiles to
+  channel-contiguous layout that stays in L1 (so the recurrence's per-time-step channel
+  loop auto-vectorises to NEON/SSE/AVX), and engages automatically once
+  `C > num_threads`. Measured on a 4-section SOS cascade (float32): **1.8–2.6× on a
+  Raspberry Pi 5** (Cortex-A76 ×4, the edge target) and **1.3–2.4× on a 12-core x86**
+  for `C` ≥ 8/16 — with **no regression** below that, since `C ≤ cores` keeps the
+  optimal scalar path. `TORCHFX_NO_SIMD=1` forces the scalar kernel. (Resolves #24.)
 - **Single-pass SOS scan (kernel-level fusion).** A new GPU path folds each cascade
   section's forcing pass and the three-phase Blelloch scan into a **single
   decoupled-look-back kernel** (Merrill–Garland / CUB style, with an atomic

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,9 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   effect to many `Wave` signals in a **single** native kernel launch by padding them to a
   common length and concatenating on the channel dimension (the causal per-channel kernels
   make this numerically identical to processing each signal separately). Fills the GPU and
-  amortises Python dispatch + OpenMP setup — **2.5–4.1× faster on CPU** for 8–512 stereo
-  files, more on GPU. For per-channel-independent effects (filters, `Gain`, dynamics);
-  see `benchmarks/bench_batch.py`. (Resolves #19.)
+  amortises Python dispatch + OpenMP setup — measured **~2.5–7× faster on CPU** and
+  **~3–4× on GPU** for 8–512 stereo files (8th-order Butterworth). For
+  per-channel-independent effects (filters, `Gain`, dynamics); see
+  `benchmarks/bench_batch.py`. (Resolves #19.)
 - **`Limiter` — look-ahead brick-wall peak limiter.** Guarantees `|y| <= threshold` (a
   true brick wall) while staying transparent: a short `lookahead` reduces the gain
   *before* a peak (a vectorised forward max-pool computes the look-ahead window), the gain

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -65,6 +65,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path on both sm_86 (RTX 3070) and sm_89 (L40S); the decoupled look-back's forward
   progress is validated across 46–142 SMs.
 
+### Changed
+
+- **`Reverb` reworked into a Freeverb-style algorithmic reverb.** The single feedforward
+  comb is replaced by the classic Schroeder/Moorer structure — 8 parallel
+  low-pass-feedback comb filters summed through 4 series all-pass diffusers per channel —
+  for a dense, natural decay, in a native per-channel C++/CUDA kernel. **Breaking:** the
+  constructor is now `Reverb(room_size, damping, mix, fs)` (was `Reverb(delay, decay,
+  mix)`); it needs `fs` (supplied by a `Wave` pipeline) to scale the delay tunings. CLI
+  `reverb:room_size=…,damping=…,mix=…`. (Resolves #18.)
+
 ## [0.6.0] - 2026-06-04
 
 ### Added

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`Expander` / `Gate` dynamics effects.** A downward expander — the mirror of the
+  compressor, attenuating *below* the threshold — with `ratio`/`knee`/`attack`/`release`,
+  an optional `floor` (range), and peak or RMS detection. `Gate` is the infinite-ratio
+  convenience (a hard noise gate). Detection runs in the same native per-channel
+  C++/CUDA kernel style as the compressor (`expander_forward`). Usage:
+  `wave | Expander(threshold=-40, ratio=2)` or `wave | Gate(threshold=-50, floor=-80)`.
+  (Resolves #32.)
 - **`Compressor` dynamics effect.** A feed-forward dynamic-range compressor with a
   decoupled peak detector (release max-hold + attack one-pole), a soft-knee dB gain
   curve (`threshold`/`ratio`/`knee`), `makeup_gain`, peak or RMS detection, and a

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`Compressor` dynamics effect.** A feed-forward dynamic-range compressor with a
+  decoupled peak detector (release max-hold + attack one-pole), a soft-knee dB gain
+  curve (`threshold`/`ratio`/`knee`), `makeup_gain`, peak or RMS detection, and a
+  `ratio=inf` brick-wall limiter mode. Detection runs in a native per-channel
+  C++/CUDA kernel (`compressor_forward`). Usage: `wave | Compressor(threshold=-18,
+  ratio=4)`. (Resolves #30.)
 - **Single-pass SOS scan (kernel-level fusion).** A new GPU path folds each cascade
   section's forcing pass and the three-phase Blelloch scan into a **single
   decoupled-look-back kernel** (Merrill–Garland / CUB style, with an atomic

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-09
+
 ### Added
 
 - **`torchfx.batch_process(waves, effect)` — batched multi-signal processing.** Applies an

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,8 @@ Python_add_library(torchfx_ext MODULE WITH_SOABI
   "${CSRC_DIR}/cpu/delay_cpu.cpp"
   "${CSRC_DIR}/cpu/compressor_cpu.cpp"
   "${CSRC_DIR}/cpu/expander_cpu.cpp"
-  "${CSRC_DIR}/cpu/limiter_cpu.cpp")
+  "${CSRC_DIR}/cpu/limiter_cpu.cpp"
+  "${CSRC_DIR}/cpu/reverb_cpu.cpp")
 
 if(TORCHFX_USE_CUDA)
   target_sources(torchfx_ext PRIVATE
@@ -94,7 +95,8 @@ if(TORCHFX_USE_CUDA)
     "${CSRC_DIR}/cuda/delay_forward.cu"
     "${CSRC_DIR}/cuda/compressor_forward.cu"
     "${CSRC_DIR}/cuda/expander_forward.cu"
-    "${CSRC_DIR}/cuda/limiter_forward.cu")
+    "${CSRC_DIR}/cuda/limiter_forward.cu"
+    "${CSRC_DIR}/cuda/reverb_forward.cu")
   target_compile_definitions(torchfx_ext PRIVATE WITH_CUDA)
   set_target_properties(torchfx_ext PROPERTIES CUDA_ARCHITECTURES "${TORCHFX_CUDA_ARCHS}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,13 +82,15 @@ set(CSRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/torchfx/_csrc")
 Python_add_library(torchfx_ext MODULE WITH_SOABI
   "${CSRC_DIR}/binding.cpp"
   "${CSRC_DIR}/cpu/iir_cpu.cpp"
-  "${CSRC_DIR}/cpu/delay_cpu.cpp")
+  "${CSRC_DIR}/cpu/delay_cpu.cpp"
+  "${CSRC_DIR}/cpu/compressor_cpu.cpp")
 
 if(TORCHFX_USE_CUDA)
   target_sources(torchfx_ext PRIVATE
     "${CSRC_DIR}/cuda/parallel_scan.cu"
     "${CSRC_DIR}/cuda/biquad_forward.cu"
-    "${CSRC_DIR}/cuda/delay_forward.cu")
+    "${CSRC_DIR}/cuda/delay_forward.cu"
+    "${CSRC_DIR}/cuda/compressor_forward.cu")
   target_compile_definitions(torchfx_ext PRIVATE WITH_CUDA)
   set_target_properties(torchfx_ext PROPERTIES CUDA_ARCHITECTURES "${TORCHFX_CUDA_ARCHS}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,8 @@ Python_add_library(torchfx_ext MODULE WITH_SOABI
   "${CSRC_DIR}/cpu/iir_cpu.cpp"
   "${CSRC_DIR}/cpu/delay_cpu.cpp"
   "${CSRC_DIR}/cpu/compressor_cpu.cpp"
-  "${CSRC_DIR}/cpu/expander_cpu.cpp")
+  "${CSRC_DIR}/cpu/expander_cpu.cpp"
+  "${CSRC_DIR}/cpu/limiter_cpu.cpp")
 
 if(TORCHFX_USE_CUDA)
   target_sources(torchfx_ext PRIVATE
@@ -92,7 +93,8 @@ if(TORCHFX_USE_CUDA)
     "${CSRC_DIR}/cuda/biquad_forward.cu"
     "${CSRC_DIR}/cuda/delay_forward.cu"
     "${CSRC_DIR}/cuda/compressor_forward.cu"
-    "${CSRC_DIR}/cuda/expander_forward.cu")
+    "${CSRC_DIR}/cuda/expander_forward.cu"
+    "${CSRC_DIR}/cuda/limiter_forward.cu")
   target_compile_definitions(torchfx_ext PRIVATE WITH_CUDA)
   set_target_properties(torchfx_ext PROPERTIES CUDA_ARCHITECTURES "${TORCHFX_CUDA_ARCHS}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,14 +83,16 @@ Python_add_library(torchfx_ext MODULE WITH_SOABI
   "${CSRC_DIR}/binding.cpp"
   "${CSRC_DIR}/cpu/iir_cpu.cpp"
   "${CSRC_DIR}/cpu/delay_cpu.cpp"
-  "${CSRC_DIR}/cpu/compressor_cpu.cpp")
+  "${CSRC_DIR}/cpu/compressor_cpu.cpp"
+  "${CSRC_DIR}/cpu/expander_cpu.cpp")
 
 if(TORCHFX_USE_CUDA)
   target_sources(torchfx_ext PRIVATE
     "${CSRC_DIR}/cuda/parallel_scan.cu"
     "${CSRC_DIR}/cuda/biquad_forward.cu"
     "${CSRC_DIR}/cuda/delay_forward.cu"
-    "${CSRC_DIR}/cuda/compressor_forward.cu")
+    "${CSRC_DIR}/cuda/compressor_forward.cu"
+    "${CSRC_DIR}/cuda/expander_forward.cu")
   target_compile_definitions(torchfx_ext PRIVATE WITH_CUDA)
   set_target_properties(torchfx_ext PROPERTIES CUDA_ARCHITECTURES "${TORCHFX_CUDA_ARCHS}")
 endif()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,11 +147,15 @@ Run specific test file:
 uv run pytest tests/test_wave.py
 ```
 
-Run with coverage:
+Run with coverage (matching CI):
 
 ```bash
-uv run pytest --cov=src/torchfx --cov-report=html
+uv run coverage run -m pytest
+uv run coverage report -m
+uv run coverage html -d htmlcov
 ```
+
+The CI coverage job also uploads `coverage.xml` to Codecov, which powers the coverage badge in the README.
 
 ### Writing Tests
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![arXiv](https://img.shields.io/badge/arXiv-2504.08624-b31b1b.svg)](https://arxiv.org/abs/2504.08624)
 [![PyPI version](https://badge.fury.io/py/torchfx.svg)](https://badge.fury.io/py/torchfx)
 ![PyPI - Status](https://img.shields.io/pypi/status/torchfx)
+[![codecov](https://codecov.io/gh/matteospanio/torchfx/branch/master/graph/badge.svg)](https://codecov.io/gh/matteospanio/torchfx)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/matteospanio/torchfx)
 
 **[Documentation](https://matteospanio.github.io/torchfx/)** | **[Getting Started](https://matteospanio.github.io/torchfx/guides/getting-started/getting_started.html)** | **[API Reference](https://matteospanio.github.io/torchfx/api/index.html)** | **[Blog](https://matteospanio.github.io/torchfx/blog/index.html)**

--- a/benchmarks/bench_batch.py
+++ b/benchmarks/bench_batch.py
@@ -28,7 +28,7 @@ def _design():
 
 def _bench(device: str, n_files: int, channels: int, samples: int, reps: int = 5):
     waves = [
-        fx.Wave(torch.randn(channels, samples, dtype=torch.float32, device=device), FS)
+        fx.Wave(torch.randn(channels, samples, dtype=torch.float32), FS, device=device)
         for _ in range(n_files)
     ]
 

--- a/benchmarks/bench_batch.py
+++ b/benchmarks/bench_batch.py
@@ -1,0 +1,67 @@
+"""Benchmark: batched multi-signal processing vs one-at-a-time (issue #19).
+
+Processing many short signals one at a time underuses the GPU (few threads per launch,
+one launch per file). ``fx.batch_process`` concatenates them on the channel dimension and
+issues a single launch over all channels. This script reports the wall-clock of both for a
+sweep of file counts, on CPU and (if available) CUDA.
+
+Run::
+
+    uv run python benchmarks/bench_batch.py
+"""
+
+from __future__ import annotations
+
+import time
+
+import torch
+
+import torchfx as fx
+from torchfx.filter.iir import LoButterworth
+
+FS = 48000
+
+
+def _design():
+    return LoButterworth(4000, order=8)
+
+
+def _bench(device: str, n_files: int, channels: int, samples: int, reps: int = 5):
+    waves = [
+        fx.Wave(torch.randn(channels, samples, dtype=torch.float32, device=device), FS)
+        for _ in range(n_files)
+    ]
+
+    def one_by_one():
+        return [(w | _design()).ys for w in waves]
+
+    def batched():
+        return fx.batch_process(waves, _design())
+
+    def timeit(fn):
+        fn()  # warmup
+        if device == "cuda":
+            torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        for _ in range(reps):
+            fn()
+        if device == "cuda":
+            torch.cuda.synchronize()
+        return (time.perf_counter() - t0) / reps * 1e3  # ms
+
+    return timeit(one_by_one), timeit(batched)
+
+
+def main() -> None:
+    devices = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
+    channels, samples = 2, FS  # stereo, 1 s
+    for dev in devices:
+        print(f"\n# {dev} | stereo x 1s @ {FS} Hz | 8th-order Butterworth")
+        print("# files | one-by-one |   batched |  speedup")
+        for n in (8, 32, 128, 512):
+            t_obo, t_bat = _bench(dev, n, channels, samples)
+            print(f"  {n:5d} | {t_obo:8.2f}ms | {t_bat:7.2f}ms | {t_obo / t_bat:6.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/slurm/bench_a40.sbatch
+++ b/benchmarks/slurm/bench_a40.sbatch
@@ -27,6 +27,9 @@ export PATH="/usr/local/cuda/bin:$PATH"
 export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 export CUDACXX="${CUDACXX:-/usr/local/cuda/bin/nvcc}"
 export UV_LINK_MODE=copy
+# Keep uv's cache + build temp off the (quota-limited) home filesystem.
+export UV_CACHE_DIR="${UV_CACHE_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/.uvcache}"
+mkdir -p "$UV_CACHE_DIR"
 
 module load GCC >/dev/null 2>&1 || true
 module load CUDA >/dev/null 2>&1 || true
@@ -39,7 +42,10 @@ fi
 echo ">>> nvcc: $(nvcc --version | tail -n 1)"
 echo ">>> SLURM_JOB_ID=$SLURM_JOB_ID hostname=$(hostname)"
 
-uv sync --all-groups --no-cache
+# --reinstall-package forces a rebuild of the editable extension; plain `uv sync`
+# (even with --no-cache) treats an installed torchfx as satisfied and skips the
+# rebuild after a `git pull`, leaving a STALE .so that runs the OLD kernels.
+uv sync --all-groups --reinstall-package torchfx
 
 uv run --no-sync python - <<'PY'
 import torch

--- a/benchmarks/slurm/bench_l40s.sbatch
+++ b/benchmarks/slurm/bench_l40s.sbatch
@@ -36,6 +36,9 @@ export PATH="/usr/local/cuda/bin:$PATH"
 export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 export CUDACXX="${CUDACXX:-/usr/local/cuda/bin/nvcc}"
 export UV_LINK_MODE=copy
+# Keep uv's cache + build temp off the (quota-limited) home filesystem.
+export UV_CACHE_DIR="${UV_CACHE_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/.uvcache}"
+mkdir -p "$UV_CACHE_DIR"
 
 module load GCC >/dev/null 2>&1 || true
 module load CUDA >/dev/null 2>&1 || true
@@ -50,7 +53,10 @@ echo ">>> SLURM_JOB_ID=$SLURM_JOB_ID hostname=$(hostname)"
 
 # ---- Dependency sync ---------------------------------------------------------
 echo ">>> Syncing dependencies (clean cache)"
-uv sync --all-groups --no-cache
+# --reinstall-package forces a rebuild of the editable extension; plain `uv sync`
+# (even with --no-cache) treats an installed torchfx as satisfied and skips the
+# rebuild after a `git pull`, leaving a STALE .so that runs the OLD kernels.
+uv sync --all-groups --reinstall-package torchfx
 
 
 # ---- CUDA preflight ----------------------------------------------------------

--- a/benchmarks/slurm/bench_rtx.sbatch
+++ b/benchmarks/slurm/bench_rtx.sbatch
@@ -28,6 +28,9 @@ export PATH="/usr/local/cuda/bin:$PATH"
 export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 export CUDACXX="${CUDACXX:-/usr/local/cuda/bin/nvcc}"
 export UV_LINK_MODE=copy
+# Keep uv's cache + build temp off the (quota-limited) home filesystem.
+export UV_CACHE_DIR="${UV_CACHE_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/.uvcache}"
+mkdir -p "$UV_CACHE_DIR"
 
 module load GCC >/dev/null 2>&1 || true
 module load CUDA >/dev/null 2>&1 || true
@@ -40,7 +43,10 @@ fi
 echo ">>> nvcc: $(nvcc --version | tail -n 1)"
 echo ">>> SLURM_JOB_ID=$SLURM_JOB_ID hostname=$(hostname)"
 
-uv sync --all-groups --no-cache
+# --reinstall-package forces a rebuild of the editable extension; plain `uv sync`
+# (even with --no-cache) treats an installed torchfx as satisfied and skips the
+# rebuild after a `git pull`, leaving a STALE .so that runs the OLD kernels.
+uv sync --all-groups --reinstall-package torchfx
 
 uv run --no-sync python - <<'PY'
 import torch

--- a/benchmarks/slurm/run_cuda_tests.sbatch
+++ b/benchmarks/slurm/run_cuda_tests.sbatch
@@ -24,6 +24,9 @@ export PATH="/usr/local/cuda/bin:$PATH"
 export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 export CUDACXX="${CUDACXX:-/usr/local/cuda/bin/nvcc}"
 export UV_LINK_MODE=copy
+# Keep uv's cache + build temp off the (quota-limited) home filesystem.
+export UV_CACHE_DIR="${UV_CACHE_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/.uvcache}"
+mkdir -p "$UV_CACHE_DIR"
 
 module load GCC >/dev/null 2>&1 || true
 module load CUDA >/dev/null 2>&1 || true
@@ -45,7 +48,10 @@ echo "Results: ${RESULTS_DIR}"
 echo ""
 
 echo ">>> Syncing dependencies (clean resolver/cache)"
-uv sync --all-groups --no-cache
+# --reinstall-package forces a rebuild of the editable extension; plain `uv sync`
+# (even with --no-cache) treats an installed torchfx as satisfied and skips the
+# rebuild after a `git pull`, leaving a STALE .so that runs the OLD kernels.
+uv sync --all-groups --reinstall-package torchfx
 
 
 echo ">>> CUDA native dispatch preflight"

--- a/benchmarks/slurm/run_profiles.sbatch
+++ b/benchmarks/slurm/run_profiles.sbatch
@@ -35,6 +35,9 @@ export PATH="/usr/local/cuda/bin:$PATH"
 export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 export CUDACXX="${CUDACXX:-/usr/local/cuda/bin/nvcc}"
 export UV_LINK_MODE=copy
+# Keep uv's cache + build temp off the (quota-limited) home filesystem.
+export UV_CACHE_DIR="${UV_CACHE_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/.uvcache}"
+mkdir -p "$UV_CACHE_DIR"
 
 module load GCC >/dev/null 2>&1 || true
 module load CUDA >/dev/null 2>&1 || true
@@ -46,7 +49,10 @@ fi
 echo "nvcc: $(nvcc --version | tail -n 1)"
 
 echo ">>> Syncing dependencies (clean resolver/cache)"
-uv sync --all-groups --no-cache
+# --reinstall-package forces a rebuild of the editable extension; plain `uv sync`
+# (even with --no-cache) treats an installed torchfx as satisfied and skips the
+# rebuild after a `git pull`, leaving a STALE .so that runs the OLD kernels.
+uv sync --all-groups --reinstall-package torchfx
 
 
 echo ">>> CUDA native dispatch preflight"

--- a/benchmarks/slurm/soak_fused_scan.sbatch
+++ b/benchmarks/slurm/soak_fused_scan.sbatch
@@ -1,0 +1,101 @@
+#!/bin/bash
+#SBATCH --job-name=tfx-soak-fused
+#SBATCH --partition=allgroups
+#SBATCH --output=benchmarks/results/soak-fused-%j.out
+#SBATCH --error=benchmarks/results/soak-fused-%j.err
+#SBATCH --gres=gpu:l40s:1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=32G
+#SBATCH --time=01:30:00
+#
+# Soak test for the single-pass decoupled-look-back SOS scan (TORCHFX_FUSED_SCAN=1).
+# Validates the kernel's forward progress and numerical correctness on a GPU
+# architecture other than the RTX 3070 it was developed on, so the fused path can be
+# made the default with confidence. The decoupled look-back's deadlock-free forward
+# progress depends on block scheduling, which differs by SM count / architecture --
+# this is exactly what we want to confirm on L40S (sm_89) and A40 (sm_86).
+#
+# Submit for each GPU type (override --gres):
+#     sbatch benchmarks/slurm/soak_fused_scan.sbatch                  # L40S (gpu7)
+#     sbatch --gres=gpu:a40:1 benchmarks/slurm/soak_fused_scan.sbatch # A40  (gpu1/5/6)
+
+set -euo pipefail
+cd "${SLURM_SUBMIT_DIR:-$PWD}"
+
+export PATH="/usr/local/cuda/bin:$PATH"
+export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
+export CUDACXX="${CUDACXX:-/usr/local/cuda/bin/nvcc}"
+export UV_LINK_MODE=copy
+# Keep uv's cache + build temp off the (quota-limited) home filesystem.
+export UV_CACHE_DIR="${UV_CACHE_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/.uvcache}"
+mkdir -p "$UV_CACHE_DIR"
+module load GCC >/dev/null 2>&1 || true
+module load CUDA >/dev/null 2>&1 || true
+command -v nvcc >/dev/null 2>&1 || { echo "ERROR: nvcc not found"; exit 2; }
+
+echo "=== TorchFX single-pass-scan soak ==="
+echo "Job ${SLURM_JOB_ID} on $(hostname) @ $(date -Iseconds)"
+echo "git: $(git rev-parse --short HEAD) ($(git branch --show-current 2>/dev/null))"
+nvcc --version | tail -1
+
+echo ">>> build (scikit-build-core compiles the .cu kernels for this node's arch)"
+# IMPORTANT: --reinstall-package forces a rebuild of the editable extension. Plain
+# `uv sync` (even with --no-cache) treats an already-installed torchfx as satisfied
+# and does NOT recompile after a `git pull`, leaving a stale .so — which silently
+# tests/benchmarks the OLD kernels (e.g. an old sos_forward signature -> TypeError).
+uv sync --all-groups --reinstall-package torchfx
+
+uv run --no-sync python - <<'PY'
+import torch
+print("GPU:", torch.cuda.get_device_name(0))
+p = torch.cuda.get_device_properties(0)
+print(f"compute capability sm_{p.major}{p.minor}, {p.multi_processor_count} SMs, {p.total_memory/1e9:.1f} GB")
+PY
+
+echo ""
+echo ">>> [1/5] forced-fused equivalence + forward-progress test file"
+TORCHFX_FUSED_SCAN=1 uv run --no-sync python -m pytest tests/test_fused_scan_equivalence.py -q
+
+echo ""
+echo ">>> [2/5] FULL SUITE via the fused path (the soak)"
+TORCHFX_FUSED_SCAN=1 uv run --no-sync python -m pytest tests/ -q
+
+echo ""
+echo ">>> [3/5] default (oracle) full suite -- no-regression check"
+uv run --no-sync python -m pytest tests/ -q
+
+echo ""
+echo ">>> [4/5] launch counts + wall-time: oracle vs single-pass"
+echo "--- oracle (3-phase) ---"
+uv run --no-sync python tools/count_kernel_launches.py --device cuda --depths 5 10 20 50 --duration 5 --iters 20
+echo "--- single-pass (TORCHFX_FUSED_SCAN=1) ---"
+TORCHFX_FUSED_SCAN=1 uv run --no-sync python tools/count_kernel_launches.py --device cuda --depths 5 10 20 50 --duration 5 --iters 20
+
+echo ""
+echo ">>> [5/5] deep forward-progress stress (up to ~2048 tiles, 8 channels)"
+TORCHFX_FUSED_SCAN=1 uv run --no-sync python - <<'PY'
+import numpy as np
+import torch
+from scipy.signal import butter, sosfilt
+from torchfx._ops import parallel_iir_forward
+
+sos_np = np.concatenate([butter(2, c, output="sos") for c in (0.1, 0.2, 0.3, 0.4)], axis=0)
+for t in (262_144, 1_048_576):  # ~512 and ~2048 tiles of 512 samples
+    for dt in (torch.float32, torch.float64):
+        g = torch.Generator().manual_seed(t)
+        x = torch.randn(8, t, generator=g, dtype=dt)
+        sos = torch.tensor(sos_np, dtype=dt, device="cuda")
+        y, _, _ = parallel_iir_forward(x.cuda(), sos, None, None, sos_cpu=sos.cpu(), threshold=0)
+        torch.cuda.synchronize()
+        assert torch.isfinite(y).all(), (t, dt)
+        ref = torch.tensor(sosfilt(sos_np, x.double().numpy(), axis=-1), dtype=dt)
+        md = (y.cpu() - ref).abs().max().item()
+        tol = 5e-3 if dt == torch.float32 else 1e-7
+        ok = md < tol
+        print(f"  T={t:>9} {str(dt):>14} tiles~{t//512:<4} max|y-scipy|={md:.2e} {'OK' if ok else 'FAIL'}")
+        assert ok, (t, dt, md)
+print("deep forward-progress stress: PASS")
+PY
+
+echo ""
+echo "=== soak complete: PASS ==="

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+# Codecov configuration.
+#
+# CI (.github/workflows/ci.yml) runs the suite under coverage and uploads coverage.xml,
+# which measures `src/torchfx` (see [tool.coverage] in pyproject.toml). The absolute level
+# is gated in CI by coverage's own `fail_under = 87`; the statuses below add per-PR signal
+# on top of that — guard against drops and keep new code covered — without being flaky.
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto        # don't drop below the base branch...
+        threshold: 1%       # ...by more than 1% (run-to-run noise margin)
+    patch:
+      default:
+        target: 80%         # changed lines in a PR should be well covered
+        threshold: 5%
+
+comment:
+  layout: "reach, diff, files"
+  require_changes: true     # only comment when coverage actually changes
+
+# Mirror coverage's `omit`: the sounddevice backend is unreachable on the CPU-only CI box.
+ignore:
+  - "src/torchfx/realtime/sounddevice_backend.py"

--- a/docs/source/blog/2026-06-09-release-070.md
+++ b/docs/source/blog/2026-06-09-release-070.md
@@ -1,0 +1,96 @@
+---
+blogpost: true
+date: Jun 09, 2026
+author: Matteo Spanio
+category: releases
+tags: release, dynamics, reverb, simd, performance, edge, tooling
+---
+
+# TorchFX 0.7.0: A Dynamics Suite, a Real Reverb, and the Edge
+
+**TorchFX 0.7.0** delivers exactly what 0.6.0's "what's next" promised — the single-pass GPU scan, a cache-blocked CPU SIMD path for edge devices, and a full dynamics toolkit — and then some. The headline is **dynamics**: a `Compressor`, an `Expander`/`Gate`, and a look-ahead brick-wall `Limiter`, each a native per-channel C++/CUDA kernel. Alongside them the old toy `Reverb` is replaced by a proper **Freeverb-style** algorithmic reverb, many short signals can now be processed in a **single batched launch**, and the whole release ships itself: tagging, PyPI, and these very release notes are now automated.
+
+One breaking change: `Reverb`'s constructor changed (see below). Everything else from 0.6.x runs unchanged.
+
+## A full dynamics toolkit
+
+Four new dynamics processors, all built on the same high-quality decoupled peak detector (release max-hold + attack one-pole; Giannoulis, Massberg & Reiss, 2012) running one channel per thread in C++/CUDA:
+
+- **`Compressor`** — threshold/ratio/attack/release, soft knee, makeup gain, peak or RMS detection, and a `ratio=inf` limiter mode.
+- **`Expander` / `Gate`** — the mirror of the compressor: attenuate *below* the threshold. `Gate` is the infinite-ratio convenience (a hard noise gate) with an optional `floor` (range).
+- **`Limiter`** — a **look-ahead brick-wall** peak limiter. A vectorised forward max-pool computes the look-ahead window, the gain is attack/release-smoothed, and a per-sample clamp **guarantees `|y| ≤ threshold`** — so unlike `Compressor(ratio=inf)`, it can never overshoot a single sample.
+
+```python
+import torchfx as fx
+
+mastered = (
+    wave
+    | fx.effect.Compressor(threshold=-18, ratio=3, attack=0.005, release=0.08)
+    | fx.effect.Limiter(threshold=-1.0, lookahead=0.005)
+)
+```
+
+## A reverb worth the name
+
+The old `Reverb` was a single feedforward comb — barely a reverb. 0.7.0 replaces it with the classic **Schroeder/Moorer (Freeverb) structure**: per channel, **8 parallel low-pass-feedback comb filters** summed through **4 series all-pass diffusers**, in a fused native kernel (ring buffers in per-channel scratch, tunings scaled to the sample rate) for a dense, natural decay.
+
+```python
+# Breaking change: room_size / damping / mix (was delay / decay / mix)
+hall = fx.effect.Reverb(room_size=0.85, damping=0.3, mix=0.25)
+```
+
+## Performance: the GPU scan, and the edge
+
+Two kernel-level wins close out the 0.6.0 roadmap, plus a new batching path.
+
+### Single-pass SOS scan (GPU)
+
+The fused cascade's forcing pass and the three-phase Blelloch scan are folded into **one decoupled-look-back kernel** (Merrill–Garland / CUB style, with an atomic per-section tile dispenser for deadlock-free forward progress). Per fused section drops from ~8 CUDA launches to **2**:
+
+| K=50 cascade (RTX 3070) | 3-phase | single-pass | |
+|---|---:|---:|---:|
+| CUDA launches | 600 | **102** | **5.9× fewer** |
+| Fused cascade time | 18.9 ms | **9.9 ms** | **~1.9×** |
+
+It's now the default GPU path (`TORCHFX_FUSED_SCAN=0` for the legacy oracle), bit-exact to it on sm_86 and sm_89.
+
+### Cache-blocked cross-channel CPU SIMD (the edge)
+
+When channels outnumber CPU cores, the scalar kernel runs them serially. A new path packs a SIMD vector of channels using **L1-resident tile transposes** (the fix for an earlier full-transpose attempt that went memory-bound), gated to `C > cores`. Validated on a **Raspberry Pi 5** (Cortex-A76 ×4) — the edge target:
+
+| 4-section SOS, float32 | Pi 5 | 12-core x86 |
+|---|---:|---:|
+| C=8 | **1.8×** | scalar (≤ cores) |
+| C=16 | **2.6×** | **1.3×** |
+| C=32 | **2.6×** | **2.4×** |
+
+No regression below the gate — a win on both the edge device and the desktop.
+
+### Batched multi-signal processing
+
+`torchfx.batch_process(waves, effect)` pads many signals to a common length, concatenates them on the channel dimension, and runs the effect in a **single** kernel launch — numerically identical to per-file, but filling the GPU and amortising dispatch overhead. **~2.5–7× faster on CPU and ~3–4× on GPU** for 8–512 stereo files. Ideal for the CLI batch/watch modes.
+
+## Tooling that ships itself
+
+- **Automated releases.** A version bump on `master` now tags `vX.Y.Z`, publishes the wheels to PyPI and the CUDA index, **and** opens a GitHub Release whose notes are the CHANGELOG section for that version. (This post's release ran through it.)
+- **Performance-regression gates** in ordinary CI — deterministic dispatch-count invariants (a depth-K cascade must fuse to *one* native call) plus a same-machine relative-time smoke, so fusion can't silently regress.
+- **Codecov** project/patch status, a **profiling guide** for diagnosing pipelines, and a fix for the flaky CUDA-wheel disk-space failures.
+
+## Installation
+
+```bash
+pip install torchfx==0.7.0
+```
+
+CUDA wheels from the GitHub Pages index:
+
+```bash
+pip install torch --index-url https://download.pytorch.org/whl/cu128
+pip install torchfx==0.7.0 \
+    --index-url https://matteospanio.github.io/torchfx/wheels/cu128/ \
+    --extra-index-url https://pypi.org/simple
+```
+
+## What's next
+
+With dynamics and the headline kernel work landed, the focus turns to the **v0.8.0 realtime milestone** — PipeWire/JACK integration and a GPU realtime path — plus production effects (chorus, flanger, phaser) on the road to v1.0. The full list of changes is in the [CHANGELOG](https://github.com/matteospanio/torchfx/blob/master/CHANGELOG); issues and feature requests are welcome on [GitHub](https://github.com/matteospanio/torchfx).

--- a/docs/source/guides/developer/index.md
+++ b/docs/source/guides/developer/index.md
@@ -10,6 +10,7 @@ Resources and guidelines for TorchFX contributors and developers.
 project-structure
 testing
 benchmarking
+profiling
 documentation
 style_guide
 releasing
@@ -21,6 +22,7 @@ roadmap
 - [Project Structure](project-structure.md) - Repository organization and module architecture
 - [Testing](testing.md) - Test infrastructure, patterns, and coverage
 - [Benchmarking](benchmarking.md) - Performance measurement and comparison
+- [Profiling](profiling.md) - Diagnosing where time goes in a pipeline, and the usual fixes
 - [Documentation](documentation.md) - Documentation build system and writing guide
 - [Style Guide](style_guide.md) - Coding standards and best practices
 - [Releasing](releasing.md) - How a version bump becomes a published release

--- a/docs/source/guides/developer/profiling.md
+++ b/docs/source/guides/developer/profiling.md
@@ -1,0 +1,107 @@
+# Profiling pipelines
+
+How to find where time goes in a TorchFX pipeline, and the usual fixes. For *comparative*
+measurement against a baseline see {doc}`/guides/developer/benchmarking`; this guide is
+about diagnosing a single pipeline.
+
+## Time it correctly first
+
+Three things will give you wrong numbers if you skip them:
+
+- **Warm up.** Filters compute their coefficients lazily on the *first* `forward`, and the
+  native extension's first call pays one-time setup. Run the pipeline a few times before
+  timing.
+- **Synchronise CUDA.** Kernel launches are asynchronous, so `perf_counter` around a GPU
+  call measures only the *launch*, not the work. Call `torch.cuda.synchronize()` before
+  reading the clock.
+- **Use the median**, not a single sample — the OS scheduler adds multi-millisecond
+  outliers (see the realtime tail discussion in the benchmarking guide).
+
+```python
+import time
+import torch
+import torchfx as fx
+
+wave = fx.Wave(torch.randn(2, 480_000), 48_000)
+chain = fx.filter.HiButterworth(80, order=4) | fx.filter.LoButterworth(12_000, order=8)
+
+for _ in range(3):                      # warm up (lazy coeffs + first-call setup)
+    _ = wave | chain
+
+samples = []
+for _ in range(20):
+    torch.cuda.synchronize() if wave.ys.is_cuda else None
+    t0 = time.perf_counter_ns()
+    _ = wave | chain
+    torch.cuda.synchronize() if wave.ys.is_cuda else None
+    samples.append(time.perf_counter_ns() - t0)
+samples.sort()
+print(f"median {samples[len(samples)//2] / 1e6:.3f} ms")
+```
+
+## The kernel timeline with `torch.profiler`
+
+To see *which* operations dominate (and, on CUDA, the launch vs. compute split):
+
+```python
+from torch.profiler import profile, ProfilerActivity
+
+acts = [ProfilerActivity.CPU]
+if wave.ys.is_cuda:
+    acts.append(ProfilerActivity.CUDA)
+
+with profile(activities=acts, record_shapes=True) as prof:
+    for _ in range(10):
+        _ = wave | chain
+
+print(prof.key_averages().table(sort_by="self_cuda_time_total", row_limit=15))
+# CPU-only: sort_by="self_cpu_time_total"
+```
+
+Look for the `torchfx_ext::` entries (`sos_forward`, `biquad_forward`, …) — those are the
+native kernels. A long tail of many short native calls usually means the chain **didn't
+fuse** (see below). Export a Chrome trace with `prof.export_chrome_trace("trace.json")`
+and open it in `chrome://tracing` for a visual timeline.
+
+## Counting native dispatches
+
+The single most useful TorchFX-specific check: how many times does the pipeline cross into
+the native extension? A fused IIR cascade should be **one** dispatch regardless of depth.
+
+```bash
+uv run python tools/count_kernel_launches.py --depths 2,5,10,20
+```
+
+It reports `native_calls` (Python→C++ dispatches) and `cuda_launches` for the fused vs.
+unfused paths. In your own code, wrap the dispatch to count it (the mechanism
+`tests/test_perf_regression.py` uses):
+
+```python
+from torchfx import _ops
+
+orig = _ops.parallel_iir_forward
+calls = 0
+def counted(*a, **k):
+    global calls; calls += 1
+    return orig(*a, **k)
+_ops.parallel_iir_forward = counted
+_ = wave | chain
+print("SOS dispatches:", calls)   # 1 if the cascade fused
+_ops.parallel_iir_forward = orig
+```
+
+## Common bottlenecks and fixes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Many short `sos_forward` calls | IIR filters applied one at a time | Build the chain with `\|` so the deferred planner **fuses** consecutive IIR/biquads into one `FusedSOSCascade`; avoid forcing materialisation between them. |
+| GPU slower than expected on float32 in | Input upcast to float64 | Pass float32 tensors — the kernels dispatch on dtype and run the FP32 path (≈3× on consumer GPUs). |
+| High per-chunk latency on short GPU chunks | Per-section launch overhead dominates | Use `torchfx.realtime.CudaGraphRunner` to replay a fixed-shape forward as one graph launch. |
+| Throughput-bound over many short files | One launch per file, low occupancy | `torchfx.batch_process(waves, effect)` runs them in a single launch. |
+| Sequential vs. parallel scan crossover | Signal length near `PARALLEL_SCAN_THRESHOLD` | Tune the `threshold=` argument (dtype-aware default); `benchmarks/bench_threshold_sweep.py`. |
+
+## See also
+
+- {doc}`/guides/developer/benchmarking` — comparative benchmarking and the suite layout.
+- {doc}`/guides/developer/testing` — the deterministic perf-regression gates that keep
+  fusion from silently breaking.

--- a/docs/source/guides/developer/releasing.md
+++ b/docs/source/guides/developer/releasing.md
@@ -11,6 +11,7 @@ When the merge commit lands on `master`, [`release.yml`](https://github.com/matt
 
 - Reads the new version out of `pyproject.toml`.
 - If a tag `v<version>` doesn't exist yet, it creates and pushes one (`v0.5.4`, `v0.6.0`, ...).
+- Creates a **GitHub Release** for the tag whose notes are the `## [<version>]` section of the `CHANGELOG`, extracted by [`tools/extract_changelog.py`](https://github.com/matteospanio/torchfx/blob/master/tools/extract_changelog.py). So the CHANGELOG entry you write in step 1 *is* the release notes — make sure it has a matching `## [<version>]` header (a placeholder is used if it doesn't).
 - Dispatches [`wheels.yml`](https://github.com/matteospanio/torchfx/blob/master/.github/workflows/wheels.yml) and [`wheels-cuda.yml`](https://github.com/matteospanio/torchfx/blob/master/.github/workflows/wheels-cuda.yml) against the new tag.
 
 The wheel workflows then:
@@ -24,6 +25,7 @@ If you re-merge to `master` without changing the version, `release.yml` is a no-
 flowchart LR
     PR["Version-bump PR"] --> Merge["Merge to master"]
     Merge --> Release["release.yml<br/>(detects bump,<br/>tags vX.Y.Z)"]
+    Release --> Notes["GitHub Release<br/>(CHANGELOG section)"]
     Release -->|workflow_dispatch| CPU["wheels.yml<br/>cibuildwheel × 4 OSes"]
     Release -->|workflow_dispatch| GPU["wheels-cuda.yml<br/>cu124 + cu128"]
     CPU --> PyPI["PyPI<br/>(trusted publishing)"]

--- a/docs/source/guides/developer/roadmap.md
+++ b/docs/source/guides/developer/roadmap.md
@@ -451,16 +451,23 @@ landed the high-leverage wins. The remaining kernel-level optimizations — inve
 prioritized, and (where attempted) measured during the 0.6.0 cycle — are tracked here.
 Each item lists its difficulty and expected impact; none block a release.
 
-- [ ] **Single-kernel SOS-section fusion (mega-kernel)** — *hard.* One CUDA kernel that
-  processes all `K` sections of a cascade (sections serial within a block, time-blocks
-  parallel) instead of the per-section launch loop. **The only item that makes fusion
-  *kernel-level*** rather than Python-dispatch-level: today a fused cascade still issues
-  `~4·K` launches (700 → 406 at `K=50`). Expected **15–27%** wall-time at `K≥5`, larger
-  at small chunks. Depends on the FP32 templating + the once-per-forward scratch (both done).
-- [ ] **Single-pass scan** — *medium.* Replace the Blelloch up/down-sweep + phase-3
-  recompute with a decoupled-look-back single-pass scan (CUB `DeviceScan` with a 3×3-matrix
-  operator, or hand-rolled). The phase-3 recompute roughly doubles scan work; ~2% overall,
-  but it simplifies the code and de-risks the mega-kernel.
+- [x] **Single-pass scan (kernel-level fusion)** — *done, opt-in.* Each cascade section's
+  forcing pass + 3-phase Blelloch scan are folded into one **decoupled-look-back** kernel
+  (Merrill–Garland / CUB style, atomic per-section tile dispenser for deadlock-free forward
+  progress), and the per-section DF1 state update into one more — so a fused section is
+  **2 CUDA launches** instead of ~8, with the phase-3 recompute eliminated. Measured on an
+  RTX 3070 vs the 3-phase path: **5.9× fewer launches** (600 → 102 at K=50) and **~1.9×
+  faster** cascades; fused launches now sit *below* the unfused baseline (102 vs 400). This
+  is the item that makes fusion **kernel-level**, not just Python-dispatch-level. Opt-in via
+  `TORCHFX_FUSED_SCAN=1` (3-phase path stays the default) pending multi-GPU (L40S/A40) soak
+  before flipping the default. Source: `fused_scan_kernel` / `state_update_kernel` in
+  [parallel_scan.cu](src/torchfx/_csrc/cuda/parallel_scan.cu).
+- [ ] **Full all-sections mega-kernel** — *hard, future.* The single-pass scan above makes
+  each section one kernel but the K sections are still K separate launches (cross-section
+  dependency = a grid-wide barrier). A single kernel over all K sections (sections serial
+  within a block, cooperative-groups grid sync) would take the launch count to `O(1)`. Lower
+  marginal value now that per-section is already 2 launches; revisit if launch overhead
+  resurfaces at very high K / tiny chunks.
 - [ ] **Pinned host buffers + async H2D/D2H for GPU streaming** — *medium.* Overlap chunk
   transfers with compute. Only pays off once a **GPU realtime/streaming I/O path** exists
   (the live path is CPU-only today), so deferred until that lands.

--- a/docs/source/guides/developer/roadmap.md
+++ b/docs/source/guides/developer/roadmap.md
@@ -393,9 +393,10 @@ TorchFX v1.0.0 will be a production-ready, GPU-accelerated audio DSP library wit
 - [x] **Optimized delay line**
   - ✅ CUDA delay forward kernel
 
-- [ ] **Reverb optimization**
-  - Parallel all-pass filters
-  - Fused feedback delay network
+- [x] **Reverb optimization** (#18) — `Reverb` reworked into a Freeverb-style network: 8
+  parallel low-pass-feedback comb filters + 4 series all-pass diffusers per channel, in a
+  fused native per-channel C++/CUDA kernel (ring buffers in per-channel scratch). Replaces
+  the single feedforward comb; breaking API (`room_size`/`damping`/`mix`/`fs`).
 
 ### 4.4 Batch Processing Optimizations
 

--- a/docs/source/guides/developer/roadmap.md
+++ b/docs/source/guides/developer/roadmap.md
@@ -472,14 +472,17 @@ Each item lists its difficulty and expected impact; none block a release.
 - [ ] **Pinned host buffers + async H2D/D2H for GPU streaming** — *medium.* Overlap chunk
   transfers with compute. Only pays off once a **GPU realtime/streaming I/O path** exists
   (the live path is CPU-only today), so deferred until that lands.
-- [ ] **Cache-blocked cross-channel CPU SIMD** — *medium, edge-focused.* A naive
-  full-transpose SIMD kernel was tried in 0.6.0 and **measured a 4–8× regression** on a
-  10-core desktop: the transpose moves as much memory as the streaming-light recurrence
-  computes, and the scalar OpenMP-over-channels path already saturates the cores. A
-  cache-blocked transpose (tiles that stay in L1/L2, state carried across time blocks)
-  could win, but the payoff is concentrated on **few-core edge devices (Raspberry Pi 5)**
-  and needs that hardware to validate. The scalar path is already near-optimal on
-  multi-core (8-ch, 10 s @ 48 kHz ≈ 3.5 ms).
+- [x] **Cache-blocked cross-channel CPU SIMD** — *done (#24).* A naive full-transpose
+  SIMD kernel (F1) regressed 4–8× on a 10-core desktop — the whole-`[C,T]` transpose
+  moved as much memory as the streaming-light recurrence computes. The fix: transpose
+  only small `[W=4, B=256]` tiles that stay in **L1**, auto-vectorise the per-time-step
+  channel loop (NEON/SSE/AVX), and **gate the path to `C > num_threads`** so the
+  scalar kernel stays for `C ≤ cores`. Validated on a **Raspberry Pi 5** (Cortex-A76
+  ×4): **1.8× at C=8, 2.6× at C=16/32**; and on **x86 (12 cores)**: 1.3–2.4× for
+  `C > cores`, **no regression** below. Correct vs scalar + `scipy.signal.sosfilt`
+  (full suite green with `TORCHFX_FORCE_SIMD=1`). `TORCHFX_NO_SIMD=1` forces scalar.
+  Source: `sos_forward_cpu_simd_impl` in
+  [iir_cpu.cpp](src/torchfx/_csrc/cpu/iir_cpu.cpp).
 - [ ] **CPU runtime feature dispatch (function multiversioning)** — *small.* Ship AVX2/AVX-512
   CPU paths without `-march=native` breaking wheel portability (paired with the SIMD work above).
 

--- a/docs/source/guides/developer/roadmap.md
+++ b/docs/source/guides/developer/roadmap.md
@@ -680,9 +680,10 @@ Each item lists its difficulty and expected impact; none block a release.
   - Self-hosted or cloud GPU
   - CUDA tests and benchmarks
 
-- [ ] **Automated releases**
-  - PyPI publishing on tag
-  - Changelog generation
+- [x] **Automated releases** (#29) — `release.yml` already auto-tags on a `pyproject.toml`
+  version bump and the wheel workflows publish to PyPI / the CUDA index on the tag. Now it
+  also publishes a **GitHub Release** whose notes are the `## [<version>]` CHANGELOG
+  section (`tools/extract_changelog.py`). See the developer releasing guide.
 
 ---
 

--- a/docs/source/guides/developer/roadmap.md
+++ b/docs/source/guides/developer/roadmap.md
@@ -451,16 +451,17 @@ landed the high-leverage wins. The remaining kernel-level optimizations — inve
 prioritized, and (where attempted) measured during the 0.6.0 cycle — are tracked here.
 Each item lists its difficulty and expected impact; none block a release.
 
-- [x] **Single-pass scan (kernel-level fusion)** — *done, opt-in.* Each cascade section's
-  forcing pass + 3-phase Blelloch scan are folded into one **decoupled-look-back** kernel
-  (Merrill–Garland / CUB style, atomic per-section tile dispenser for deadlock-free forward
-  progress), and the per-section DF1 state update into one more — so a fused section is
-  **2 CUDA launches** instead of ~8, with the phase-3 recompute eliminated. Measured on an
+- [x] **Single-pass scan (kernel-level fusion)** — *done, default-on (0.7.0).* Each cascade
+  section's forcing pass + 3-phase Blelloch scan are folded into one **decoupled-look-back**
+  kernel (Merrill–Garland / CUB style, atomic per-section tile dispenser for deadlock-free
+  forward progress), and the per-section DF1 state update into one more — so a fused section
+  is **2 CUDA launches** instead of ~8, with the phase-3 recompute eliminated. Measured on an
   RTX 3070 vs the 3-phase path: **5.9× fewer launches** (600 → 102 at K=50) and **~1.9×
   faster** cascades; fused launches now sit *below* the unfused baseline (102 vs 400). This
-  is the item that makes fusion **kernel-level**, not just Python-dispatch-level. Opt-in via
-  `TORCHFX_FUSED_SCAN=1` (3-phase path stays the default) pending multi-GPU (L40S/A40) soak
-  before flipping the default. Source: `fused_scan_kernel` / `state_update_kernel` in
+  is the item that makes fusion **kernel-level**, not just Python-dispatch-level. Now the
+  **default**; set `TORCHFX_FUSED_SCAN=0` to force the legacy 3-phase oracle. Validated on
+  sm_86 (RTX 3070, 46 SMs) and sm_89 (L40S, 142 SMs) — forward progress holds across the SM
+  range. Source: `fused_scan_kernel` / `state_update_kernel` in
   [parallel_scan.cu](src/torchfx/_csrc/cuda/parallel_scan.cu).
 - [ ] **Full all-sections mega-kernel** — *hard, future.* The single-pass scan above makes
   each section one kernel but the K sections are still K separate launches (cross-section

--- a/docs/source/guides/developer/roadmap.md
+++ b/docs/source/guides/developer/roadmap.md
@@ -423,8 +423,8 @@ TorchFX v1.0.0 will be a production-ready, GPU-accelerated audio DSP library wit
 - [x] **Multi-file batch processing** (#19) — `torchfx.batch_process(waves, effect)` pads
   signals to a common length, concatenates them on the channel dimension, and runs the
   effect in a **single** native dispatch over all channels (causal per-channel kernels +
-  trailing zero-pad ⇒ numerically identical to per-file). Measured **2.5–4.1× faster on
-  CPU** for 8–512 stereo files (8th-order Butterworth); larger on GPU via occupancy. See
+  trailing zero-pad ⇒ numerically identical to per-file). Measured **~2.5–7× on CPU and
+  ~3–4× on GPU** for 8–512 stereo files (8th-order Butterworth). See
   `benchmarks/bench_batch.py`.
 
 ### 4.5 Performance Benchmarking ✅

--- a/docs/source/guides/developer/roadmap.md
+++ b/docs/source/guides/developer/roadmap.md
@@ -420,9 +420,12 @@ TorchFX v1.0.0 will be a production-ready, GPU-accelerated audio DSP library wit
   - ✅ Reverb op fusion (5 tensor ops → 2)
   - ✅ Delay wet/dry mix via `torch.lerp` (3 ops → 1)
 
-- [ ] **Multi-file batch processing**
-  - Process multiple files in single kernel launch
-  - Maximize GPU occupancy
+- [x] **Multi-file batch processing** (#19) — `torchfx.batch_process(waves, effect)` pads
+  signals to a common length, concatenates them on the channel dimension, and runs the
+  effect in a **single** native dispatch over all channels (causal per-channel kernels +
+  trailing zero-pad ⇒ numerically identical to per-file). Measured **2.5–4.1× faster on
+  CPU** for 8–512 stereo files (8th-order Butterworth); larger on GPU via occupancy. See
+  `benchmarks/bench_batch.py`.
 
 ### 4.5 Performance Benchmarking ✅
 

--- a/docs/source/guides/developer/roadmap.md
+++ b/docs/source/guides/developer/roadmap.md
@@ -437,9 +437,11 @@ TorchFX v1.0.0 will be a production-ready, GPU-accelerated audio DSP library wit
   - ✅ CPU `torch.profiler` findings captured
   - ✅ Coverage gate `fail_under = 87` enforced in CI
 
-- [ ] **Performance regression testing**
-  - Automated benchmarks in CI
-  - Alert on >5% regression
+- [x] **Performance regression testing** (#21) — `tests/test_perf_regression.py` runs in
+  ordinary CI and gates on *deterministic* invariants (fusion collapses a depth-K cascade
+  to one native dispatch; a static `Gain` folds without adding one) plus a same-machine
+  relative wall-time smoke. Avoids flaky absolute-timing baselines on shared runners; see
+  the developer testing guide. (Absolute wall-time budgets would need a dedicated runner.)
 
 - [ ] **Profiling guides**
   - Documentation for profiling pipelines

--- a/docs/source/guides/developer/roadmap.md
+++ b/docs/source/guides/developer/roadmap.md
@@ -446,8 +446,9 @@ TorchFX v1.0.0 will be a production-ready, GPU-accelerated audio DSP library wit
   relative wall-time smoke. Avoids flaky absolute-timing baselines on shared runners; see
   the developer testing guide. (Absolute wall-time budgets would need a dedicated runner.)
 
-- [ ] **Profiling guides**
-  - Documentation for profiling pipelines
+- [x] **Profiling guides** (#22) — developer guide on diagnosing a pipeline: correct
+  warm-up/CUDA-sync timing, `torch.profiler` timelines, counting native dispatches to spot
+  un-fused chains, and a bottleneck→fix table. See the developer profiling guide.
 
 ### 4.6 Advanced Kernel Optimizations (Future)
 
@@ -668,7 +669,9 @@ Each item lists its difficulty and expected impact; none block a release.
 - [x] **Coverage reporting**
   - ✅ HTML coverage CI job on Python 3.12
   - ✅ `fail_under = 87` coverage gate enforced
-  - [ ] Codecov integration
+  - ✅ Codecov integration (#26) — CI uploads `coverage.xml` via `codecov-action`, README
+    badge, and a `codecov.yml` with project/patch status targets (ignoring the
+    CPU-unreachable sounddevice backend)
   - [ ] Coverage badge
 
 - [ ] **Multi-platform testing**

--- a/docs/source/guides/developer/roadmap.md
+++ b/docs/source/guides/developer/roadmap.md
@@ -688,9 +688,12 @@ Each item lists its difficulty and expected impact; none block a release.
 
 ### 7.1 Dynamics Processing
 
-- [ ] Compressor (threshold, ratio, attack, release, knee)
+- [x] Compressor (threshold, ratio, attack, release, knee) — `Compressor` (#30), native
+  per-channel C++/CUDA detector, peak/RMS, soft knee, `ratio=inf` limiter mode.
 - [ ] Limiter (brickwall, true peak, look-ahead)
-- [ ] Expander / Gate
+- [x] Expander / Gate — `Expander` (downward expansion below threshold) + `Gate`
+  (infinite-ratio convenience) (#32), mirroring the compressor detector with an
+  optional `floor` (range); native CPU + CUDA.
 
 ### 7.2 Modulation Effects
 

--- a/docs/source/guides/developer/roadmap.md
+++ b/docs/source/guides/developer/roadmap.md
@@ -690,7 +690,10 @@ Each item lists its difficulty and expected impact; none block a release.
 
 - [x] Compressor (threshold, ratio, attack, release, knee) — `Compressor` (#30), native
   per-channel C++/CUDA detector, peak/RMS, soft knee, `ratio=inf` limiter mode.
-- [ ] Limiter (brickwall, true peak, look-ahead)
+- [x] Limiter (brickwall, look-ahead) — `Limiter` (#31): look-ahead windowed peak
+  (vectorised max-pool) + attack/release gain smoothing + a per-sample clamp that
+  guarantees `|y| <= threshold`; native CPU + CUDA. (True-peak / oversampled detection
+  is a possible follow-up.)
 - [x] Expander / Gate — `Expander` (downward expansion below threshold) + `Gate`
   (infinite-ratio convenience) (#32), mirroring the compressor detector with an
   optional `floor` (range); native CPU + CUDA.

--- a/docs/source/guides/developer/testing.md
+++ b/docs/source/guides/developer/testing.md
@@ -777,6 +777,27 @@ def test_gain():  # Depends on test_setup
     assert torch.allclose(gain(global_waveform), torch.ones(5) * 2.0)
 ```
 
+## Performance-regression gates
+
+`tests/test_perf_regression.py` guards the headline performance wins against silent
+regressions, and **runs in ordinary CI** (no separate workflow or GPU needed). Because
+shared CI runners are noisy, it does **not** compare absolute wall-times against a stored
+baseline (which is flaky); it asserts the *deterministic* invariants those wins depend on:
+
+- **Fusion collapses dispatches.** A depth-`K` IIR cascade `wave | (f1 | ... | fK)` must
+  execute as exactly **one** native SOS dispatch (the unfused reference issues `K`), and a
+  static `Gain` folded between sections must not add one. Dispatches are counted by
+  wrapping the `torchfx._ops` entry points — the same mechanism as
+  `tools/count_kernel_launches.py`. If the planner ever stops fusing, the count jumps and
+  the test fails.
+- **A relative wall-time smoke.** With both modules pre-built (so planning cost is
+  excluded), the fused *forward* must not be slower than `K` separate forwards. This is a
+  ratio on the same machine, so it is speed-independent, and the margin is generous
+  (`< 1.1×`) so it only trips on a catastrophic regression.
+
+When you add a new fused or kernel-level fast path, add a deterministic invariant here
+(dispatch/launch count, or a same-machine ratio) rather than an absolute timing budget.
+
 ## Related Resources
 
 - {doc}`/guides/developer/project-structure` - Project organization

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "torchfx"
-version = "0.6.0"
+version = "0.7.0"
 description = "A GPU accelerated library for audio DSP based on PyTorch"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/cli/commands/play.py
+++ b/src/cli/commands/play.py
@@ -33,7 +33,7 @@ def play_cmd(
     Examples
     --------
       torchfx play song.wav
-      torchfx play recording.wav -e normalize -e "reverb:decay=0.4"
+      torchfx play recording.wav -e normalize -e "reverb:room_size=0.4"
 
     """
     import numpy as np

--- a/src/cli/commands/preset.py
+++ b/src/cli/commands/preset.py
@@ -85,7 +85,7 @@ def preset_save_cmd(
     \b
     Examples
     --------
-      torchfx preset save mastering -e normalize -e "reverb:decay=0.4,mix=0.2"
+      torchfx preset save mastering -e normalize -e "reverb:room_size=0.4,mix=0.2"
       torchfx preset save loud --from my_chain.toml
 
     """

--- a/src/cli/commands/process.py
+++ b/src/cli/commands/process.py
@@ -193,7 +193,7 @@ def process_cmd(
     \b
     Examples
     --------
-      torchfx process in.wav out.wav -e normalize -e "reverb:decay=0.6"
+      torchfx process in.wav out.wav -e normalize -e "reverb:room_size=0.6"
       torchfx process "*.wav" -O ./processed/ -e gain:0.5
       cat in.wav | torchfx process - - -e normalize | aplay
       torchfx process in.wav out.wav --config chain.toml

--- a/src/cli/commands/record.py
+++ b/src/cli/commands/record.py
@@ -50,7 +50,7 @@ def record_cmd(
     --------
       torchfx record out.wav --duration 10
       torchfx record out.wav -t 5 -r 48000 -C 2
-      torchfx record out.wav -t 10 -e normalize -e "reverb:decay=0.3"
+      torchfx record out.wav -t 10 -e normalize -e "reverb:room_size=0.3"
 
     """
     import torch

--- a/src/cli/commands/watch.py
+++ b/src/cli/commands/watch.py
@@ -52,7 +52,7 @@ def watch_cmd(
     \b
     Examples
     --------
-      torchfx watch ./input/ ./output/ -e normalize -e "reverb:decay=0.4"
+      torchfx watch ./input/ ./output/ -e normalize -e "reverb:room_size=0.4"
       torchfx watch ./bounces/ ./mastered/ --config master.toml
       torchfx watch ./raw/ ./processed/ --preset vocal-cleanup --recursive
 

--- a/src/cli/parsing.py
+++ b/src/cli/parsing.py
@@ -13,7 +13,7 @@ String format
 Examples::
 
     gain:0.5
-    reverb:decay=0.6,mix=0.3
+    reverb:room_size=0.6,mix=0.3
     normalize
     lowpass:cutoff=1000,order=4
     parametriceq:frequency=2000,q=1.5,gain=6,gain_scale=db
@@ -24,7 +24,7 @@ TOML configuration
 
     [[effects]]
     name = "reverb"
-    decay = 0.6
+    room_size = 0.6
     mix = 0.3
 
     [[effects]]
@@ -79,7 +79,7 @@ EFFECT_REGISTRY: dict[str, tuple[type[FX], list[str]]] = {
     # ── effects ──────────────────────────────────────────────
     "gain": (Gain, ["gain"]),
     "normalize": (Normalize, ["peak"]),
-    "reverb": (Reverb, ["delay", "decay", "mix"]),
+    "reverb": (Reverb, ["room_size", "damping", "mix"]),
     "delay": (Delay, ["delay_samples", "feedback", "mix"]),
     # ── biquad filters ──────────────────────────────────────
     "lowpass": (BiquadLPF, ["cutoff", "q"]),
@@ -251,7 +251,7 @@ def load_effects_from_config(path: str | Path) -> list[FX]:
 
         [[effects]]
         name = "reverb"
-        decay = 0.6
+        room_size = 0.6
         mix = 0.3
 
         [[effects]]

--- a/src/cli/repl.py
+++ b/src/cli/repl.py
@@ -67,7 +67,7 @@ _HELP_TEXT = """\
 [bold cyan]TorchFX Interactive REPL[/bold cyan]
 
   [green]load[/green] <file>                     Load an audio file
-  [green]add[/green] <effect-spec>               Add an effect (e.g. reverb:decay=0.5)
+  [green]add[/green] <effect-spec>               Add an effect (e.g. reverb:room_size=0.5)
   [green]remove[/green] <index>                  Remove effect at index (1-based)
   [green]list[/green]                            Show current effect chain
   [green]effects[/green]                         List all available effects

--- a/src/torchfx/__init__.py
+++ b/src/torchfx/__init__.py
@@ -5,6 +5,7 @@ import torchfx.realtime as realtime
 import torchfx.typing as typing
 import torchfx.validation as validation
 from torchfx._ops import is_native_available
+from torchfx.batch import batch_process
 from torchfx.chain import FilterChain
 from torchfx.effect import FX
 from torchfx.wave import Wave
@@ -20,4 +21,5 @@ __all__ = [
     "logging",
     "realtime",
     "is_native_available",
+    "batch_process",
 ]

--- a/src/torchfx/_csrc/binding.cpp
+++ b/src/torchfx/_csrc/binding.cpp
@@ -3,6 +3,7 @@
 #ifdef WITH_CUDA
 #include "torchfx/biquad_kernel.h"
 #include "torchfx/delay_kernel.h"
+#include "torchfx/compressor_kernel.h"
 #endif
 
 // CPU implementation declarations
@@ -25,6 +26,17 @@ torch::Tensor delay_line_forward_cpu(
     int delay_samples,
     double decay,
     double mix);
+
+torch::Tensor compressor_forward_cpu(
+    const torch::Tensor& x,
+    double threshold_db,
+    double inv_ratio,
+    double knee_db,
+    double makeup_db,
+    double attack_coeff,
+    double release_coeff,
+    double rms_coeff,
+    int detector);
 
 // Dispatch: select CUDA or CPU implementation based on tensor device.
 // `threshold` is the sequential-vs-parallel-scan boundary used by the CUDA path
@@ -86,6 +98,32 @@ torch::Tensor delay_line_forward(
   return delay_line_forward_cpu(x, delay_samples, decay, mix);
 }
 
+// Compressor dispatch. `inv_ratio` = 1/ratio (0 for an infinite-ratio limiter);
+// `detector` is 0=peak, 1=rms. Coefficients are precomputed by the Python layer
+// from attack/release/rms times and fs.
+torch::Tensor compressor_forward(
+    const torch::Tensor& x,
+    double threshold_db,
+    double inv_ratio,
+    double knee_db,
+    double makeup_db,
+    double attack_coeff,
+    double release_coeff,
+    double rms_coeff,
+    int detector) {
+#ifdef WITH_CUDA
+  if (x.is_cuda()) {
+    return torchfx::compressor_forward_cuda(x, threshold_db, inv_ratio, knee_db,
+                                            makeup_db, attack_coeff, release_coeff,
+                                            rms_coeff, detector);
+  }
+#else
+  TORCH_CHECK(!x.is_cuda(), "CUDA extension not compiled; move tensors to CPU");
+#endif
+  return compressor_forward_cpu(x, threshold_db, inv_ratio, knee_db, makeup_db,
+                                attack_coeff, release_coeff, rms_coeff, detector);
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("biquad_forward", &biquad_forward,
         "Biquad filter forward (CUDA/CPU)",
@@ -99,4 +137,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         "Delay line forward (CUDA only)",
         py::arg("x"), py::arg("delay_samples"),
         py::arg("decay"), py::arg("mix"));
+  m.def("compressor_forward", &compressor_forward,
+        "Compressor forward (CUDA/CPU)",
+        py::arg("x"), py::arg("threshold"), py::arg("inv_ratio"), py::arg("knee"),
+        py::arg("makeup_db"), py::arg("attack_coeff"), py::arg("release_coeff"),
+        py::arg("rms_coeff"), py::arg("detector"));
 }

--- a/src/torchfx/_csrc/binding.cpp
+++ b/src/torchfx/_csrc/binding.cpp
@@ -5,6 +5,7 @@
 #include "torchfx/delay_kernel.h"
 #include "torchfx/compressor_kernel.h"
 #include "torchfx/expander_kernel.h"
+#include "torchfx/limiter_kernel.h"
 #endif
 
 // CPU implementation declarations
@@ -49,6 +50,13 @@ torch::Tensor expander_forward_cpu(
     double release_coeff,
     double rms_coeff,
     int detector);
+
+torch::Tensor limiter_forward_cpu(
+    const torch::Tensor& x,
+    const torch::Tensor& peak_env,
+    double threshold_lin,
+    double attack_coeff,
+    double release_coeff);
 
 // Dispatch: select CUDA or CPU implementation based on tensor device.
 // `threshold` is the sequential-vs-parallel-scan boundary used by the CUDA path
@@ -162,6 +170,24 @@ torch::Tensor expander_forward(
                               attack_coeff, release_coeff, rms_coeff, detector);
 }
 
+// Look-ahead brick-wall limiter dispatch. `peak_env` is the precomputed look-ahead
+// windowed peak of |x|; `threshold_lin` is the linear ceiling.
+torch::Tensor limiter_forward(
+    const torch::Tensor& x,
+    const torch::Tensor& peak_env,
+    double threshold_lin,
+    double attack_coeff,
+    double release_coeff) {
+#ifdef WITH_CUDA
+  if (x.is_cuda()) {
+    return torchfx::limiter_forward_cuda(x, peak_env, threshold_lin, attack_coeff, release_coeff);
+  }
+#else
+  TORCH_CHECK(!x.is_cuda(), "CUDA extension not compiled; move tensors to CPU");
+#endif
+  return limiter_forward_cpu(x, peak_env, threshold_lin, attack_coeff, release_coeff);
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("biquad_forward", &biquad_forward,
         "Biquad filter forward (CUDA/CPU)",
@@ -185,4 +211,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         py::arg("x"), py::arg("threshold"), py::arg("slope"), py::arg("knee"),
         py::arg("floor_db"), py::arg("attack_coeff"), py::arg("release_coeff"),
         py::arg("rms_coeff"), py::arg("detector"));
+  m.def("limiter_forward", &limiter_forward,
+        "Look-ahead brick-wall limiter forward (CUDA/CPU)",
+        py::arg("x"), py::arg("peak_env"), py::arg("threshold_lin"),
+        py::arg("attack_coeff"), py::arg("release_coeff"));
 }

--- a/src/torchfx/_csrc/binding.cpp
+++ b/src/torchfx/_csrc/binding.cpp
@@ -6,6 +6,7 @@
 #include "torchfx/compressor_kernel.h"
 #include "torchfx/expander_kernel.h"
 #include "torchfx/limiter_kernel.h"
+#include "torchfx/reverb_kernel.h"
 #endif
 
 // CPU implementation declarations
@@ -57,6 +58,16 @@ torch::Tensor limiter_forward_cpu(
     double threshold_lin,
     double attack_coeff,
     double release_coeff);
+
+torch::Tensor reverb_forward_cpu(
+    const torch::Tensor& x,
+    int fs,
+    double feedback,
+    double damp,
+    double input_gain,
+    double allpass_fb,
+    double wet,
+    double dry);
 
 // Dispatch: select CUDA or CPU implementation based on tensor device.
 // `threshold` is the sequential-vs-parallel-scan boundary used by the CUDA path
@@ -188,6 +199,27 @@ torch::Tensor limiter_forward(
   return limiter_forward_cpu(x, peak_env, threshold_lin, attack_coeff, release_coeff);
 }
 
+// Freeverb-style reverb dispatch. Comb/all-pass tunings scale with `fs`; `feedback`,
+// `damp`, `wet`, `dry` come from the Python layer's room-size/damping/mix parameters.
+torch::Tensor reverb_forward(
+    const torch::Tensor& x,
+    int fs,
+    double feedback,
+    double damp,
+    double input_gain,
+    double allpass_fb,
+    double wet,
+    double dry) {
+#ifdef WITH_CUDA
+  if (x.is_cuda()) {
+    return torchfx::reverb_forward_cuda(x, fs, feedback, damp, input_gain, allpass_fb, wet, dry);
+  }
+#else
+  TORCH_CHECK(!x.is_cuda(), "CUDA extension not compiled; move tensors to CPU");
+#endif
+  return reverb_forward_cpu(x, fs, feedback, damp, input_gain, allpass_fb, wet, dry);
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("biquad_forward", &biquad_forward,
         "Biquad filter forward (CUDA/CPU)",
@@ -215,4 +247,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         "Look-ahead brick-wall limiter forward (CUDA/CPU)",
         py::arg("x"), py::arg("peak_env"), py::arg("threshold_lin"),
         py::arg("attack_coeff"), py::arg("release_coeff"));
+  m.def("reverb_forward", &reverb_forward,
+        "Freeverb-style reverb forward (CUDA/CPU)",
+        py::arg("x"), py::arg("fs"), py::arg("feedback"), py::arg("damp"),
+        py::arg("input_gain"), py::arg("allpass_fb"), py::arg("wet"), py::arg("dry"));
 }

--- a/src/torchfx/_csrc/binding.cpp
+++ b/src/torchfx/_csrc/binding.cpp
@@ -4,6 +4,7 @@
 #include "torchfx/biquad_kernel.h"
 #include "torchfx/delay_kernel.h"
 #include "torchfx/compressor_kernel.h"
+#include "torchfx/expander_kernel.h"
 #endif
 
 // CPU implementation declarations
@@ -33,6 +34,17 @@ torch::Tensor compressor_forward_cpu(
     double inv_ratio,
     double knee_db,
     double makeup_db,
+    double attack_coeff,
+    double release_coeff,
+    double rms_coeff,
+    int detector);
+
+torch::Tensor expander_forward_cpu(
+    const torch::Tensor& x,
+    double threshold_db,
+    double slope,
+    double knee_db,
+    double floor_db,
     double attack_coeff,
     double release_coeff,
     double rms_coeff,
@@ -124,6 +136,32 @@ torch::Tensor compressor_forward(
                                 attack_coeff, release_coeff, rms_coeff, detector);
 }
 
+// Expander / gate dispatch. `slope` = ratio-1 (a large finite value for a gate, so the
+// kernel never does inf arithmetic); `floor_db` is the deepest attenuation; `detector`
+// is 0=peak, 1=rms. Coefficients are precomputed by the Python layer.
+torch::Tensor expander_forward(
+    const torch::Tensor& x,
+    double threshold_db,
+    double slope,
+    double knee_db,
+    double floor_db,
+    double attack_coeff,
+    double release_coeff,
+    double rms_coeff,
+    int detector) {
+#ifdef WITH_CUDA
+  if (x.is_cuda()) {
+    return torchfx::expander_forward_cuda(x, threshold_db, slope, knee_db,
+                                          floor_db, attack_coeff, release_coeff,
+                                          rms_coeff, detector);
+  }
+#else
+  TORCH_CHECK(!x.is_cuda(), "CUDA extension not compiled; move tensors to CPU");
+#endif
+  return expander_forward_cpu(x, threshold_db, slope, knee_db, floor_db,
+                              attack_coeff, release_coeff, rms_coeff, detector);
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("biquad_forward", &biquad_forward,
         "Biquad filter forward (CUDA/CPU)",
@@ -141,5 +179,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         "Compressor forward (CUDA/CPU)",
         py::arg("x"), py::arg("threshold"), py::arg("inv_ratio"), py::arg("knee"),
         py::arg("makeup_db"), py::arg("attack_coeff"), py::arg("release_coeff"),
+        py::arg("rms_coeff"), py::arg("detector"));
+  m.def("expander_forward", &expander_forward,
+        "Expander / gate forward (CUDA/CPU)",
+        py::arg("x"), py::arg("threshold"), py::arg("slope"), py::arg("knee"),
+        py::arg("floor_db"), py::arg("attack_coeff"), py::arg("release_coeff"),
         py::arg("rms_coeff"), py::arg("detector"));
 }

--- a/src/torchfx/_csrc/cpu/compressor_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/compressor_cpu.cpp
@@ -1,0 +1,115 @@
+#include <torch/torch.h>
+#include <algorithm>
+#include <cmath>
+
+// CPU feed-forward compressor with a decoupled peak detector. One channel per
+// OpenMP thread, sequential over time (the ballistics are a nonlinear recurrence).
+// See include/torchfx/compressor_kernel.h for the per-sample math.
+
+#if defined(_MSC_VER)
+#define TORCHFX_RESTRICT __restrict
+#else
+#define TORCHFX_RESTRICT __restrict__
+#endif
+
+template <typename scalar_t>
+static void compressor_loop(
+    const scalar_t* TORCHFX_RESTRICT in_ptr,
+    scalar_t* TORCHFX_RESTRICT out_ptr,
+    int64_t C,
+    int64_t T,
+    scalar_t threshold_db,
+    scalar_t inv_ratio,
+    scalar_t knee_db,
+    scalar_t makeup_db,
+    scalar_t attack_coeff,
+    scalar_t release_coeff,
+    scalar_t rms_coeff,
+    int detector) {
+
+  const scalar_t eps = static_cast<scalar_t>(1e-12);
+  const scalar_t one = static_cast<scalar_t>(1);
+  const scalar_t two = static_cast<scalar_t>(2);
+  const scalar_t twenty = static_cast<scalar_t>(20);
+
+  #pragma omp parallel for schedule(static) if(C > 1)
+  for (int64_t c = 0; c < C; ++c) {
+    const scalar_t* in_c = in_ptr + c * T;
+    scalar_t* out_c = out_ptr + c * T;
+
+    scalar_t y1 = 0, yL = 0, ms = 0;
+    for (int64_t n = 0; n < T; ++n) {
+      const scalar_t xn = in_c[n];
+
+      scalar_t rect;
+      if (detector == 1) {  // RMS
+        ms = rms_coeff * ms + (one - rms_coeff) * xn * xn;
+        rect = std::sqrt(ms);
+      } else {  // peak
+        rect = std::abs(xn);
+      }
+
+      y1 = std::max(rect, release_coeff * y1);            // release max-hold
+      yL = attack_coeff * yL + (one - attack_coeff) * y1;  // attack one-pole
+
+      const scalar_t L = twenty * std::log10(std::max(yL, eps));
+      const scalar_t over = L - threshold_db;
+      scalar_t Lsc;
+      if (knee_db > 0 && two * std::abs(over) <= knee_db) {
+        const scalar_t t = over + knee_db / two;
+        Lsc = L + (inv_ratio - one) * t * t / (two * knee_db);
+      } else if (over > 0) {
+        Lsc = threshold_db + over * inv_ratio;
+      } else {
+        Lsc = L;
+      }
+
+      const scalar_t gdb = (Lsc - L) + makeup_db;
+      const scalar_t g = std::pow(static_cast<scalar_t>(10), gdb / twenty);
+      out_c[n] = g * xn;
+    }
+  }
+}
+
+torch::Tensor compressor_forward_cpu(
+    const torch::Tensor& x,
+    double threshold_db,
+    double inv_ratio,
+    double knee_db,
+    double makeup_db,
+    double attack_coeff,
+    double release_coeff,
+    double rms_coeff,
+    int detector) {
+
+  TORCH_CHECK(!x.is_cuda(), "compressor_forward_cpu: input must be on CPU");
+
+  auto x_cont = x.contiguous();
+  const int orig_dim = x_cont.dim();
+  if (orig_dim == 1) {
+    x_cont = x_cont.unsqueeze(0);
+  }
+
+  const int64_t C = x_cont.size(0);
+  const int64_t T = x_cont.size(1);
+  auto output = torch::empty_like(x_cont);
+
+  if (x_cont.dtype() == torch::kFloat32) {
+    compressor_loop<float>(
+        x_cont.data_ptr<float>(), output.data_ptr<float>(), C, T,
+        static_cast<float>(threshold_db), static_cast<float>(inv_ratio),
+        static_cast<float>(knee_db), static_cast<float>(makeup_db),
+        static_cast<float>(attack_coeff), static_cast<float>(release_coeff),
+        static_cast<float>(rms_coeff), detector);
+  } else {
+    compressor_loop<double>(
+        x_cont.data_ptr<double>(), output.data_ptr<double>(), C, T,
+        threshold_db, inv_ratio, knee_db, makeup_db,
+        attack_coeff, release_coeff, rms_coeff, detector);
+  }
+
+  if (orig_dim == 1) {
+    return output.squeeze(0);
+  }
+  return output;
+}

--- a/src/torchfx/_csrc/cpu/expander_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/expander_cpu.cpp
@@ -1,0 +1,115 @@
+#include <torch/torch.h>
+#include <algorithm>
+#include <cmath>
+
+// CPU downward expander / noise gate with a decoupled peak detector. One channel per
+// OpenMP thread, sequential over time (the ballistics are a nonlinear recurrence).
+// See include/torchfx/expander_kernel.h for the per-sample math.
+
+#if defined(_MSC_VER)
+#define TORCHFX_RESTRICT __restrict
+#else
+#define TORCHFX_RESTRICT __restrict__
+#endif
+
+template <typename scalar_t>
+static void expander_loop(
+    const scalar_t* TORCHFX_RESTRICT in_ptr,
+    scalar_t* TORCHFX_RESTRICT out_ptr,
+    int64_t C,
+    int64_t T,
+    scalar_t threshold_db,
+    scalar_t slope,
+    scalar_t knee_db,
+    scalar_t floor_db,
+    scalar_t attack_coeff,
+    scalar_t release_coeff,
+    scalar_t rms_coeff,
+    int detector) {
+
+  const scalar_t eps = static_cast<scalar_t>(1e-12);
+  const scalar_t one = static_cast<scalar_t>(1);
+  const scalar_t two = static_cast<scalar_t>(2);
+  const scalar_t twenty = static_cast<scalar_t>(20);
+
+  #pragma omp parallel for schedule(static) if(C > 1)
+  for (int64_t c = 0; c < C; ++c) {
+    const scalar_t* in_c = in_ptr + c * T;
+    scalar_t* out_c = out_ptr + c * T;
+
+    scalar_t y1 = 0, yL = 0, ms = 0;
+    for (int64_t n = 0; n < T; ++n) {
+      const scalar_t xn = in_c[n];
+
+      scalar_t rect;
+      if (detector == 1) {  // RMS
+        ms = rms_coeff * ms + (one - rms_coeff) * xn * xn;
+        rect = std::sqrt(ms);
+      } else {  // peak
+        rect = std::abs(xn);
+      }
+
+      y1 = std::max(rect, release_coeff * y1);             // release max-hold
+      yL = attack_coeff * yL + (one - attack_coeff) * y1;  // attack one-pole
+
+      const scalar_t L = twenty * std::log10(std::max(yL, eps));
+      const scalar_t over = L - threshold_db;
+      scalar_t gdb;
+      if (knee_db > 0 && two * std::abs(over) <= knee_db) {
+        const scalar_t t = over - knee_db / two;
+        gdb = -slope * t * t / (two * knee_db);
+      } else if (over < 0) {
+        gdb = slope * over;
+      } else {
+        gdb = 0;
+      }
+      gdb = std::max(gdb, floor_db);
+
+      const scalar_t g = std::pow(static_cast<scalar_t>(10), gdb / twenty);
+      out_c[n] = g * xn;
+    }
+  }
+}
+
+torch::Tensor expander_forward_cpu(
+    const torch::Tensor& x,
+    double threshold_db,
+    double slope,
+    double knee_db,
+    double floor_db,
+    double attack_coeff,
+    double release_coeff,
+    double rms_coeff,
+    int detector) {
+
+  TORCH_CHECK(!x.is_cuda(), "expander_forward_cpu: input must be on CPU");
+
+  auto x_cont = x.contiguous();
+  const int orig_dim = x_cont.dim();
+  if (orig_dim == 1) {
+    x_cont = x_cont.unsqueeze(0);
+  }
+
+  const int64_t C = x_cont.size(0);
+  const int64_t T = x_cont.size(1);
+  auto output = torch::empty_like(x_cont);
+
+  if (x_cont.dtype() == torch::kFloat32) {
+    expander_loop<float>(
+        x_cont.data_ptr<float>(), output.data_ptr<float>(), C, T,
+        static_cast<float>(threshold_db), static_cast<float>(slope),
+        static_cast<float>(knee_db), static_cast<float>(floor_db),
+        static_cast<float>(attack_coeff), static_cast<float>(release_coeff),
+        static_cast<float>(rms_coeff), detector);
+  } else {
+    expander_loop<double>(
+        x_cont.data_ptr<double>(), output.data_ptr<double>(), C, T,
+        threshold_db, slope, knee_db, floor_db,
+        attack_coeff, release_coeff, rms_coeff, detector);
+  }
+
+  if (orig_dim == 1) {
+    return output.squeeze(0);
+  }
+  return output;
+}

--- a/src/torchfx/_csrc/cpu/iir_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/iir_cpu.cpp
@@ -1,5 +1,9 @@
 #include <torch/torch.h>
 #include <omp.h>
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <tuple>
 #include <vector>
 
@@ -194,6 +198,124 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> biquad_forward_cpu(
   return biquad_forward_cpu_impl<double>(x_exec, b_exec, a1, a2, sx_exec, sy_exec);
 }
 
+// Cache-blocked cross-channel SIMD SOS cascade (Roadmap Epic 4.6 / #24).
+//
+// The DF1 SOS recurrence is serial in time and across sections but INDEPENDENT
+// across channels, with coefficients shared by all channels. The scalar kernel
+// parallelises channels over OpenMP threads; once C > cores each thread processes
+// several channels SERIALLY (the time the throughput goes linear in C).
+//
+// This path packs a group of W channels into SIMD lanes: it transposes a small
+// [W, B] tile into channel-contiguous [B, W] (kept in L1 — unlike the reverted F1
+// attempt that transposed the whole [C, T] and went memory-bound), runs the
+// recurrence with the per-time-step channel loop auto-vectorising (#pragma omp simd),
+// and transposes the output tile back. OpenMP runs over channel groups so cores AND
+// SIMD lanes are both used. Engaged only when C > num_threads (see the dispatcher).
+template <typename scalar_t>
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> sos_forward_cpu_simd_impl(
+    const torch::Tensor& x,       // [C, T]
+    const torch::Tensor& sos,     // [K, 6]
+    const torch::Tensor& state_x, // [K, C, 2]
+    const torch::Tensor& state_y) {
+
+  auto sx = state_x.clone();
+  auto sy = state_y.clone();
+
+  const int64_t K = sos.size(0);
+  const int64_t C = x.size(0);
+  const int64_t T = x.size(1);
+
+  auto sos_acc = sos.accessor<scalar_t, 2>();
+  std::vector<scalar_t> cb0(K), cb1(K), cb2(K), ca1(K), ca2(K);
+  for (int64_t s = 0; s < K; ++s) {
+    cb0[s] = sos_acc[s][0];
+    cb1[s] = sos_acc[s][1];
+    cb2[s] = sos_acc[s][2];
+    ca1[s] = sos_acc[s][4];
+    ca2[s] = sos_acc[s][5];
+  }
+
+  auto y = torch::empty_like(x);
+  const scalar_t* xp = x.data_ptr<scalar_t>();  // [C, T] contiguous
+  scalar_t* yp = y.data_ptr<scalar_t>();
+  auto sx_acc = sx.accessor<scalar_t, 3>();  // [K, C, 2]
+  auto sy_acc = sy.accessor<scalar_t, 3>();
+
+  // Group width = one SIMD vector (4 f32 in a 128-bit NEON/SSE register). Keeping it
+  // narrow maximises the number of channel groups, so OpenMP fills the cores even at
+  // moderate C (e.g. C=8 on 4 cores -> 2 groups -> 2 cores, not 1). The inner channel
+  // loop auto-vectorises to one vector op per section per time step.
+  constexpr int64_t W = 4;
+  constexpr int64_t B = 256;  // time block; the W*B tile stays in L1
+
+  #pragma omp parallel for schedule(static) if (C > W)
+  for (int64_t c0 = 0; c0 < C; c0 += W) {
+    const int64_t cw = std::min<int64_t>(W, C - c0);
+
+    // Per-group, channel-contiguous section state [K][W] (unused lanes stay 0).
+    std::vector<scalar_t> ssx0(K * W, 0), ssx1(K * W, 0), ssy0(K * W, 0), ssy1(K * W, 0);
+    for (int64_t s = 0; s < K; ++s) {
+      for (int64_t c = 0; c < cw; ++c) {
+        ssx0[s * W + c] = sx_acc[s][c0 + c][0];
+        ssx1[s * W + c] = sx_acc[s][c0 + c][1];
+        ssy0[s * W + c] = sy_acc[s][c0 + c][0];
+        ssy1[s * W + c] = sy_acc[s][c0 + c][1];
+      }
+    }
+
+    std::vector<scalar_t> tile(B * W);
+
+    for (int64_t bt = 0; bt < T; bt += B) {
+      const int64_t bb = std::min<int64_t>(B, T - bt);
+      if (cw < W) std::memset(tile.data(), 0, sizeof(scalar_t) * bb * W);
+
+      // Load + transpose [cw, bb] -> tile[bb][W] (channel-contiguous per time step).
+      for (int64_t c = 0; c < cw; ++c) {
+        const scalar_t* xrow = xp + (c0 + c) * T + bt;
+        for (int64_t n = 0; n < bb; ++n) tile[n * W + c] = xrow[n];
+      }
+
+      // Recurrence over the tile; the channel loop (constant W) auto-vectorises.
+      for (int64_t n = 0; n < bb; ++n) {
+        scalar_t* row = &tile[n * W];
+        for (int64_t s = 0; s < K; ++s) {
+          scalar_t* __restrict px0 = &ssx0[s * W];
+          scalar_t* __restrict px1 = &ssx1[s * W];
+          scalar_t* __restrict py0 = &ssy0[s * W];
+          scalar_t* __restrict py1 = &ssy1[s * W];
+          const scalar_t b0 = cb0[s], b1 = cb1[s], b2 = cb2[s], a1 = ca1[s], a2 = ca2[s];
+          #pragma omp simd
+          for (int64_t c = 0; c < W; ++c) {
+            const scalar_t yn = b0 * row[c] + b1 * px0[c] + b2 * px1[c] - a1 * py0[c] - a2 * py1[c];
+            px1[c] = px0[c];
+            px0[c] = row[c];
+            py1[c] = py0[c];
+            py0[c] = yn;
+            row[c] = yn;  // cascade into the next section / final output
+          }
+        }
+      }
+
+      // Transpose tile[bb][cw] -> y[c0..][bt..].
+      for (int64_t c = 0; c < cw; ++c) {
+        scalar_t* yrow = yp + (c0 + c) * T + bt;
+        for (int64_t n = 0; n < bb; ++n) yrow[n] = tile[n * W + c];
+      }
+    }
+
+    for (int64_t s = 0; s < K; ++s) {
+      for (int64_t c = 0; c < cw; ++c) {
+        sx_acc[s][c0 + c][0] = ssx0[s * W + c];
+        sx_acc[s][c0 + c][1] = ssx1[s * W + c];
+        sy_acc[s][c0 + c][0] = ssy0[s * W + c];
+        sy_acc[s][c0 + c][1] = ssy1[s * W + c];
+      }
+    }
+  }
+
+  return std::make_tuple(y, sx, sy);
+}
+
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> sos_forward_cpu(
     const torch::Tensor& x,         // [C, T]
     const torch::Tensor& sos,       // [K, 6]
@@ -211,9 +333,23 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> sos_forward_cpu(
   const auto sx_exec = state_x.to(exec_dtype).contiguous();
   const auto sy_exec = state_y.to(exec_dtype).contiguous();
 
+  // Cross-channel SIMD helps only once channels outnumber cores (each thread then
+  // runs several channels serially). Below that the scalar path is already optimal,
+  // and the tile transposes would be pure overhead. TORCHFX_NO_SIMD=1 forces scalar;
+  // TORCHFX_FORCE_SIMD=1 forces the SIMD path at any C (for testing/benchmarking).
+  const char* no_simd = std::getenv("TORCHFX_NO_SIMD");
+  const char* force_simd = std::getenv("TORCHFX_FORCE_SIMD");
+  const int64_t C = x_exec.size(0);
+  const bool use_simd =
+      (no_simd == nullptr || no_simd[0] != '1') &&
+      ((force_simd != nullptr && force_simd[0] == '1') ||
+       C > static_cast<int64_t>(omp_get_max_threads()));
+
   if (exec_dtype == torch::kFloat32) {
-    return sos_forward_cpu_impl<float>(x_exec, sos_exec, sx_exec, sy_exec);
+    return use_simd ? sos_forward_cpu_simd_impl<float>(x_exec, sos_exec, sx_exec, sy_exec)
+                    : sos_forward_cpu_impl<float>(x_exec, sos_exec, sx_exec, sy_exec);
   }
 
-  return sos_forward_cpu_impl<double>(x_exec, sos_exec, sx_exec, sy_exec);
+  return use_simd ? sos_forward_cpu_simd_impl<double>(x_exec, sos_exec, sx_exec, sy_exec)
+                  : sos_forward_cpu_impl<double>(x_exec, sos_exec, sx_exec, sy_exec);
 }

--- a/src/torchfx/_csrc/cpu/iir_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/iir_cpu.cpp
@@ -7,6 +7,16 @@
 #include <tuple>
 #include <vector>
 
+// MSVC's default `/openmp` (2.0) rejects `#pragma omp simd` with a hard error (C7660,
+// it needs `/openmp:experimental`). Emit the SIMD hint only on GCC/Clang, where it is
+// validated and works with or without `-fopenmp`; MSVC still auto-vectorises the small
+// fixed-trip channel loop (its operands are `__restrict`) under `/O2`.
+#ifdef _MSC_VER
+#define TORCHFX_OMP_SIMD
+#else
+#define TORCHFX_OMP_SIMD _Pragma("omp simd")
+#endif
+
 // CPU implementation of biquad Direct Form 1.
 // Vectorized across channels, sequential across time.
 // This is significantly faster than the Python for-loop.
@@ -284,7 +294,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> sos_forward_cpu_simd_imp
           scalar_t* __restrict py0 = &ssy0[s * W];
           scalar_t* __restrict py1 = &ssy1[s * W];
           const scalar_t b0 = cb0[s], b1 = cb1[s], b2 = cb2[s], a1 = ca1[s], a2 = ca2[s];
-          #pragma omp simd
+          TORCHFX_OMP_SIMD
           for (int64_t c = 0; c < W; ++c) {
             const scalar_t yn = b0 * row[c] + b1 * px0[c] + b2 * px1[c] - a1 * py0[c] - a2 * py1[c];
             px1[c] = px0[c];

--- a/src/torchfx/_csrc/cpu/iir_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/iir_cpu.cpp
@@ -340,10 +340,18 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> sos_forward_cpu(
   const char* no_simd = std::getenv("TORCHFX_NO_SIMD");
   const char* force_simd = std::getenv("TORCHFX_FORCE_SIMD");
   const int64_t C = x_exec.size(0);
+  // omp_get_max_threads() is a runtime call; guard it so the extension still links
+  // where OpenMP is unavailable (e.g. MSVC/cibuildwheel, which doesn't link the
+  // runtime — only the #pragma omp directives, which it harmlessly ignores). Without
+  // OpenMP the SIMD path still vectorises, just single-threaded, so gate on 1.
+#ifdef _OPENMP
+  const int64_t nthreads = static_cast<int64_t>(omp_get_max_threads());
+#else
+  const int64_t nthreads = 1;
+#endif
   const bool use_simd =
       (no_simd == nullptr || no_simd[0] != '1') &&
-      ((force_simd != nullptr && force_simd[0] == '1') ||
-       C > static_cast<int64_t>(omp_get_max_threads()));
+      ((force_simd != nullptr && force_simd[0] == '1') || C > nthreads);
 
   if (exec_dtype == torch::kFloat32) {
     return use_simd ? sos_forward_cpu_simd_impl<float>(x_exec, sos_exec, sx_exec, sy_exec)

--- a/src/torchfx/_csrc/cpu/limiter_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/limiter_cpu.cpp
@@ -1,0 +1,87 @@
+#include <torch/torch.h>
+#include <algorithm>
+#include <cmath>
+
+// CPU look-ahead brick-wall limiter (gain stage). The look-ahead windowed peak is
+// precomputed; this runs the sequential gain recurrence, one channel per OpenMP thread.
+// See include/torchfx/limiter_kernel.h for the per-sample math.
+
+#if defined(_MSC_VER)
+#define TORCHFX_RESTRICT __restrict
+#else
+#define TORCHFX_RESTRICT __restrict__
+#endif
+
+template <typename scalar_t>
+static void limiter_loop(
+    const scalar_t* TORCHFX_RESTRICT in_ptr,
+    const scalar_t* TORCHFX_RESTRICT peak_ptr,
+    scalar_t* TORCHFX_RESTRICT out_ptr,
+    int64_t C,
+    int64_t T,
+    scalar_t threshold_lin,
+    scalar_t attack_coeff,
+    scalar_t release_coeff) {
+
+  const scalar_t eps = static_cast<scalar_t>(1e-12);
+  const scalar_t one = static_cast<scalar_t>(1);
+
+  #pragma omp parallel for schedule(static) if(C > 1)
+  for (int64_t c = 0; c < C; ++c) {
+    const scalar_t* in_c = in_ptr + c * T;
+    const scalar_t* peak_c = peak_ptr + c * T;
+    scalar_t* out_c = out_ptr + c * T;
+
+    scalar_t g = one;
+    for (int64_t n = 0; n < T; ++n) {
+      const scalar_t gr = std::min(one, threshold_lin / std::max(peak_c[n], eps));
+      if (gr < g) {
+        g = attack_coeff * g + (one - attack_coeff) * gr;
+      } else {
+        g = release_coeff * g + (one - release_coeff) * gr;
+      }
+      const scalar_t clamp = threshold_lin / std::max(std::abs(in_c[n]), eps);
+      const scalar_t g_out = std::min(g, clamp);
+      out_c[n] = g_out * in_c[n];
+    }
+  }
+}
+
+torch::Tensor limiter_forward_cpu(
+    const torch::Tensor& x,
+    const torch::Tensor& peak_env,
+    double threshold_lin,
+    double attack_coeff,
+    double release_coeff) {
+
+  TORCH_CHECK(!x.is_cuda(), "limiter_forward_cpu: input must be on CPU");
+  TORCH_CHECK(x.sizes() == peak_env.sizes(), "limiter_forward_cpu: x and peak_env must match");
+
+  auto x_cont = x.contiguous();
+  auto peak_cont = peak_env.contiguous();
+  const int orig_dim = x_cont.dim();
+  if (orig_dim == 1) {
+    x_cont = x_cont.unsqueeze(0);
+    peak_cont = peak_cont.unsqueeze(0);
+  }
+
+  const int64_t C = x_cont.size(0);
+  const int64_t T = x_cont.size(1);
+  auto output = torch::empty_like(x_cont);
+
+  if (x_cont.dtype() == torch::kFloat32) {
+    limiter_loop<float>(
+        x_cont.data_ptr<float>(), peak_cont.data_ptr<float>(), output.data_ptr<float>(),
+        C, T, static_cast<float>(threshold_lin), static_cast<float>(attack_coeff),
+        static_cast<float>(release_coeff));
+  } else {
+    limiter_loop<double>(
+        x_cont.data_ptr<double>(), peak_cont.data_ptr<double>(), output.data_ptr<double>(),
+        C, T, threshold_lin, attack_coeff, release_coeff);
+  }
+
+  if (orig_dim == 1) {
+    return output.squeeze(0);
+  }
+  return output;
+}

--- a/src/torchfx/_csrc/cpu/reverb_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/reverb_cpu.cpp
@@ -1,0 +1,147 @@
+#include <torch/torch.h>
+#include <algorithm>
+#include <cmath>
+#include "torchfx/reverb_kernel.h"
+
+// CPU Freeverb-style reverb. One channel per OpenMP thread; ring buffers live in a
+// zero-initialised scratch block per channel. See include/torchfx/reverb_kernel.h.
+
+#if defined(_MSC_VER)
+#define TORCHFX_RESTRICT __restrict
+#else
+#define TORCHFX_RESTRICT __restrict__
+#endif
+
+namespace {
+
+void reverb_dims(int fs, int* comb_len, int* comb_off, int* ap_len, int* ap_off,
+                 int& comb_total, int& total) {
+  comb_total = 0;
+  for (int i = 0; i < torchfx::kReverbNumCombs; ++i) {
+    const int len = std::max<int>(
+        1, static_cast<int>(std::lround(torchfx::kReverbCombTuning[i] * fs / torchfx::kReverbTuningFs)));
+    comb_len[i] = len;
+    comb_off[i] = comb_total;
+    comb_total += len;
+  }
+  int ap_total = 0;
+  for (int j = 0; j < torchfx::kReverbNumAllpass; ++j) {
+    const int len = std::max<int>(
+        1, static_cast<int>(std::lround(torchfx::kReverbAllpassTuning[j] * fs / torchfx::kReverbTuningFs)));
+    ap_len[j] = len;
+    ap_off[j] = ap_total;
+    ap_total += len;
+  }
+  total = comb_total + ap_total;
+}
+
+template <typename scalar_t>
+void reverb_loop(
+    const scalar_t* TORCHFX_RESTRICT in_ptr,
+    scalar_t* TORCHFX_RESTRICT out_ptr,
+    scalar_t* TORCHFX_RESTRICT scratch,
+    int64_t C,
+    int64_t T,
+    const int* comb_len,
+    const int* comb_off,
+    const int* ap_len,
+    const int* ap_off,
+    int comb_total,
+    int total,
+    scalar_t feedback,
+    scalar_t damp,
+    scalar_t input_gain,
+    scalar_t allpass_fb,
+    scalar_t wet,
+    scalar_t dry) {
+
+  const scalar_t one = static_cast<scalar_t>(1);
+
+  #pragma omp parallel for schedule(static) if (C > 1)
+  for (int64_t c = 0; c < C; ++c) {
+    const scalar_t* in_c = in_ptr + c * T;
+    scalar_t* out_c = out_ptr + c * T;
+    scalar_t* buf = scratch + c * total;
+
+    scalar_t fstore[torchfx::kReverbNumCombs];
+    int cidx[torchfx::kReverbNumCombs];
+    int aidx[torchfx::kReverbNumAllpass];
+    for (int i = 0; i < torchfx::kReverbNumCombs; ++i) {
+      fstore[i] = 0;
+      cidx[i] = 0;
+    }
+    for (int j = 0; j < torchfx::kReverbNumAllpass; ++j) aidx[j] = 0;
+
+    for (int64_t n = 0; n < T; ++n) {
+      const scalar_t xn = in_c[n];
+      const scalar_t inp = xn * input_gain;
+      scalar_t acc = 0;
+
+      for (int i = 0; i < torchfx::kReverbNumCombs; ++i) {
+        scalar_t* cb = buf + comb_off[i];
+        const scalar_t bo = cb[cidx[i]];
+        fstore[i] = bo * (one - damp) + fstore[i] * damp;
+        cb[cidx[i]] = inp + fstore[i] * feedback;
+        if (++cidx[i] >= comb_len[i]) cidx[i] = 0;
+        acc += bo;
+      }
+      for (int j = 0; j < torchfx::kReverbNumAllpass; ++j) {
+        scalar_t* ab = buf + comb_total + ap_off[j];
+        const scalar_t bo = ab[aidx[j]];
+        ab[aidx[j]] = acc + bo * allpass_fb;
+        acc = bo - acc;
+        if (++aidx[j] >= ap_len[j]) aidx[j] = 0;
+      }
+      out_c[n] = xn * dry + acc * wet;
+    }
+  }
+}
+
+}  // namespace
+
+torch::Tensor reverb_forward_cpu(
+    const torch::Tensor& x,
+    int fs,
+    double feedback,
+    double damp,
+    double input_gain,
+    double allpass_fb,
+    double wet,
+    double dry) {
+
+  TORCH_CHECK(!x.is_cuda(), "reverb_forward_cpu: input must be on CPU");
+
+  auto x_cont = x.contiguous();
+  const int orig_dim = x_cont.dim();
+  if (orig_dim == 1) {
+    x_cont = x_cont.unsqueeze(0);
+  }
+  const int64_t C = x_cont.size(0);
+  const int64_t T = x_cont.size(1);
+
+  int comb_len[torchfx::kReverbNumCombs], comb_off[torchfx::kReverbNumCombs];
+  int ap_len[torchfx::kReverbNumAllpass], ap_off[torchfx::kReverbNumAllpass];
+  int comb_total, total;
+  reverb_dims(fs, comb_len, comb_off, ap_len, ap_off, comb_total, total);
+
+  auto output = torch::empty_like(x_cont);
+  auto scratch = torch::zeros({C, static_cast<int64_t>(total)}, x_cont.options());
+
+  if (x_cont.dtype() == torch::kFloat32) {
+    reverb_loop<float>(
+        x_cont.data_ptr<float>(), output.data_ptr<float>(), scratch.data_ptr<float>(),
+        C, T, comb_len, comb_off, ap_len, ap_off, comb_total, total,
+        static_cast<float>(feedback), static_cast<float>(damp), static_cast<float>(input_gain),
+        static_cast<float>(allpass_fb), static_cast<float>(wet), static_cast<float>(dry));
+  } else {
+    reverb_loop<double>(
+        x_cont.data_ptr<double>(), output.data_ptr<double>(), scratch.data_ptr<double>(),
+        C, T, comb_len, comb_off, ap_len, ap_off, comb_total, total,
+        feedback, damp, input_gain, allpass_fb, wet, dry);
+  }
+
+  if (orig_dim == 1) {
+    return output.squeeze(0);
+  }
+  return output;
+}

--- a/src/torchfx/_csrc/cuda/biquad_forward.cu
+++ b/src/torchfx/_csrc/cuda/biquad_forward.cu
@@ -1,4 +1,5 @@
 #include <torch/torch.h>
+#include <cstdlib>
 #include "torchfx/parallel_scan.h"
 #include "torchfx/biquad_kernel.h"
 
@@ -91,6 +92,11 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> sos_forward_cuda(
 
   torch::Tensor section_input = x_c;
 
+  // Opt-in fused per-section path (forcing folded into the scan). Read per call so
+  // tests can A/B against the 3-phase oracle within one process. Default: oracle.
+  const char* fused_env = std::getenv("TORCHFX_FUSED_SCAN");
+  const bool use_fused = (fused_env != nullptr && fused_env[0] == '1');
+
   // Process each SOS section sequentially, reusing the scratch buffers.
   for (int64_t s = 0; s < K; ++s) {
     // Extract all coefficients from CPU copy — no GPU sync needed.
@@ -108,8 +114,13 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> sos_forward_cuda(
     // (sx_s / sy_s) first; the new state is written into the same buffers below,
     // after the reads, with no temporary allocation — so a captured CUDA graph sees
     // stable buffer addresses for the whole forward (no per-section allocs at all).
-    compute_forcing_into(section_input, b0, b1, b2, sx_s, f);
-    parallel_biquad_scan_into(f, a1, a2, sy_s, threshold, y_out, block_agg);
+    if (use_fused) {
+      fused_sos_scan_into(section_input, b0, b1, b2, a1, a2, sx_s, sy_s,
+                          threshold, y_out, f, block_agg);
+    } else {
+      compute_forcing_into(section_input, b0, b1, b2, sx_s, f);
+      parallel_biquad_scan_into(f, a1, a2, sy_s, threshold, y_out, block_agg);
+    }
 
     // New y-state = {y[-1], y[-2]} written in place into sy_s (after the scan read it).
     if (T >= 1) {

--- a/src/torchfx/_csrc/cuda/biquad_forward.cu
+++ b/src/torchfx/_csrc/cuda/biquad_forward.cu
@@ -78,10 +78,11 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> sos_forward_cuda(
   // Use the pre-supplied CPU copy — no GPU→CPU sync needed.
   auto sos_cpu = sos_cpu_in.contiguous();
 
-  // Opt-in fused per-section path (forcing folded into the scan). Read per call so
-  // tests can A/B against the 3-phase oracle within one process. Default: oracle.
+  // Fused per-section path (forcing folded into the scan) is the default. Read per
+  // call so tests can A/B against the 3-phase oracle within one process. Set
+  // TORCHFX_FUSED_SCAN=0 to force the legacy 3-phase oracle path.
   const char* fused_env = std::getenv("TORCHFX_FUSED_SCAN");
-  const bool use_fused = (fused_env != nullptr && fused_env[0] == '1');
+  const bool use_fused = (fused_env == nullptr) || (fused_env[0] != '0');
 
   // Persistent scratch reused across all sections (C3): allocated once, not per
   // section, so the per-forward kernel sequence and its buffer addresses stay stable

--- a/src/torchfx/_csrc/cuda/biquad_forward.cu
+++ b/src/torchfx/_csrc/cuda/biquad_forward.cu
@@ -135,24 +135,28 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> sos_forward_cuda(
       parallel_biquad_scan_into(f, a1, a2, sy_s, threshold, y_out, block_agg);
     }
 
-    // New y-state = {y[-1], y[-2]} written in place into sy_s (after the scan read it).
-    if (T >= 1) {
-      sy_s.select(1, 0).copy_(y_out.select(1, T - 1));
-      if (T >= 2) {
-        sy_s.select(1, 1).copy_(y_out.select(1, T - 2));
-      } else {
-        sy_s.select(1, 1).zero_();  // y[-2] = 0 for a single-sample chunk
+    // State update. The fused path updates sx_s/sy_s inside fused_sos_scan_into
+    // (one state_update_kernel launch); the oracle path does it here via copy_.
+    if (!use_fused) {
+      // New y-state = {y[-1], y[-2]} written in place into sy_s (after the scan read it).
+      if (T >= 1) {
+        sy_s.select(1, 0).copy_(y_out.select(1, T - 1));
+        if (T >= 2) {
+          sy_s.select(1, 1).copy_(y_out.select(1, T - 2));
+        } else {
+          sy_s.select(1, 1).zero_();  // y[-2] = 0 for a single-sample chunk
+        }
       }
-    }
 
-    // New x-state = {x[-1], x[-2]} of this section's input, written in place into sx_s
-    // (after compute_forcing read it). T == 0 leaves the state unchanged.
-    if (T >= 2) {
-      sx_s.select(1, 0).copy_(section_input.select(1, T - 1));
-      sx_s.select(1, 1).copy_(section_input.select(1, T - 2));
-    } else if (T == 1) {
-      sx_s.select(1, 1).copy_(sx_s.select(1, 0));  // x[-2] <- old x[-1]
-      sx_s.select(1, 0).copy_(section_input.select(1, 0));  // x[-1] <- x[0]
+      // New x-state = {x[-1], x[-2]} of this section's input, written in place into sx_s
+      // (after compute_forcing read it). T == 0 leaves the state unchanged.
+      if (T >= 2) {
+        sx_s.select(1, 0).copy_(section_input.select(1, T - 1));
+        sx_s.select(1, 1).copy_(section_input.select(1, T - 2));
+      } else if (T == 1) {
+        sx_s.select(1, 1).copy_(sx_s.select(1, 0));  // x[-2] <- old x[-1]
+        sx_s.select(1, 0).copy_(section_input.select(1, 0));  // x[-1] <- x[0]
+      }
     }
 
     section_input = y_out;

--- a/src/torchfx/_csrc/cuda/biquad_forward.cu
+++ b/src/torchfx/_csrc/cuda/biquad_forward.cu
@@ -78,24 +78,35 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> sos_forward_cuda(
   // Use the pre-supplied CPU copy — no GPU→CPU sync needed.
   auto sos_cpu = sos_cpu_in.contiguous();
 
-  // Persistent scratch reused across all sections (C3): one forcing buffer, two
-  // ping-pong output buffers, and one block-aggregate scratch — allocated once, not
-  // per section. This is what keeps the per-forward kernel sequence and its buffer
-  // addresses stable so a captured CUDA graph replays correctly (per-section
-  // allocations otherwise alias in the capture pool and corrupt the replay).
-  auto opts = x_c.options();
-  auto f = torch::empty({C, T}, opts);
-  auto y_a = torch::empty({C, T}, opts);
-  auto y_b = torch::empty({C, T}, opts);
-  const int num_blocks = (static_cast<int>(T) + 512 - 1) / 512;  // BLOCK_SIZE = 512
-  auto block_agg = torch::empty({C * num_blocks * 6}, opts);
-
-  torch::Tensor section_input = x_c;
-
   // Opt-in fused per-section path (forcing folded into the scan). Read per call so
   // tests can A/B against the 3-phase oracle within one process. Default: oracle.
   const char* fused_env = std::getenv("TORCHFX_FUSED_SCAN");
   const bool use_fused = (fused_env != nullptr && fused_env[0] == '1');
+
+  // Persistent scratch reused across all sections (C3): allocated once, not per
+  // section, so the per-forward kernel sequence and its buffer addresses stay stable
+  // for CUDA-graph replay. Two ping-pong output buffers are needed in both paths.
+  auto opts = x_c.options();
+  auto y_a = torch::empty({C, T}, opts);
+  auto y_b = torch::empty({C, T}, opts);
+  const int num_blocks = (static_cast<int>(T) + 512 - 1) / 512;  // BLOCK_SIZE = 512
+
+  // Oracle path: forcing buffer + block-aggregate scratch. Fused path: epoch-tagged
+  // status (zeroed once), aggregate/prefix scratch, and a per-(section,channel) tile
+  // dispenser (zeroed once). status/tile_counter are zeros so section 0 sees "empty".
+  auto i32 = opts.dtype(torch::kInt32);
+  torch::Tensor f, block_agg, status, aggregate, prefix, tile_counter;
+  if (use_fused) {
+    status = torch::zeros({C * num_blocks}, i32);
+    aggregate = torch::empty({C * num_blocks * 6}, opts);
+    prefix = torch::empty({C * num_blocks * 6}, opts);
+    tile_counter = torch::zeros({K * C}, i32);
+  } else {
+    f = torch::empty({C, T}, opts);
+    block_agg = torch::empty({C * num_blocks * 6}, opts);
+  }
+
+  torch::Tensor section_input = x_c;
 
   // Process each SOS section sequentially, reusing the scratch buffers.
   for (int64_t s = 0; s < K; ++s) {
@@ -115,8 +126,10 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> sos_forward_cuda(
     // after the reads, with no temporary allocation — so a captured CUDA graph sees
     // stable buffer addresses for the whole forward (no per-section allocs at all).
     if (use_fused) {
+      auto counter_s = tile_counter.narrow(0, s * C, C);  // this section's [C] dispenser
       fused_sos_scan_into(section_input, b0, b1, b2, a1, a2, sx_s, sy_s,
-                          threshold, y_out, f, block_agg);
+                          threshold, y_out, status, aggregate, prefix, counter_s,
+                          static_cast<int>(s));
     } else {
       compute_forcing_into(section_input, b0, b1, b2, sx_s, f);
       parallel_biquad_scan_into(f, a1, a2, sy_s, threshold, y_out, block_agg);

--- a/src/torchfx/_csrc/cuda/compressor_forward.cu
+++ b/src/torchfx/_csrc/cuda/compressor_forward.cu
@@ -1,0 +1,119 @@
+#include <torch/torch.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <c10/cuda/CUDAStream.h>
+#include "torchfx/compressor_kernel.h"
+
+// Feed-forward compressor with a decoupled peak detector. One thread per channel,
+// each walking its own time series sequentially (the ballistics are a nonlinear
+// recurrence — same topology as the sequential biquad). Templated on scalar_t so a
+// float32 input runs natively in FP32. See compressor_kernel.h for the math.
+
+namespace torchfx {
+
+template <typename scalar_t>
+__global__ void compressor_kernel(
+    const scalar_t* __restrict__ input,
+    scalar_t* __restrict__ output,
+    scalar_t threshold_db,
+    scalar_t inv_ratio,
+    scalar_t knee_db,
+    scalar_t makeup_db,
+    scalar_t attack_coeff,
+    scalar_t release_coeff,
+    scalar_t rms_coeff,
+    int detector,
+    int C,
+    int T) {
+
+  const int channel = blockIdx.x * blockDim.x + threadIdx.x;
+  if (channel >= C) return;
+
+  const scalar_t* in_c = input + static_cast<int64_t>(channel) * T;
+  scalar_t* out_c = output + static_cast<int64_t>(channel) * T;
+
+  const scalar_t eps = static_cast<scalar_t>(1e-12);
+  const scalar_t one = static_cast<scalar_t>(1);
+  const scalar_t two = static_cast<scalar_t>(2);
+  const scalar_t twenty = static_cast<scalar_t>(20);
+
+  scalar_t y1 = 0, yL = 0, ms = 0;
+  for (int n = 0; n < T; ++n) {
+    const scalar_t xn = in_c[n];
+
+    scalar_t rect;
+    if (detector == 1) {  // RMS
+      ms = rms_coeff * ms + (one - rms_coeff) * xn * xn;
+      rect = sqrt(ms);
+    } else {  // peak
+      rect = fabs(xn);
+    }
+
+    y1 = fmax(rect, release_coeff * y1);                 // release max-hold
+    yL = attack_coeff * yL + (one - attack_coeff) * y1;  // attack one-pole
+
+    const scalar_t L = twenty * log10(fmax(yL, eps));
+    const scalar_t over = L - threshold_db;
+    scalar_t Lsc;
+    if (knee_db > scalar_t(0) && two * fabs(over) <= knee_db) {
+      const scalar_t t = over + knee_db / two;
+      Lsc = L + (inv_ratio - one) * t * t / (two * knee_db);
+    } else if (over > scalar_t(0)) {
+      Lsc = threshold_db + over * inv_ratio;
+    } else {
+      Lsc = L;
+    }
+
+    const scalar_t gdb = (Lsc - L) + makeup_db;
+    const scalar_t g = pow(static_cast<scalar_t>(10), gdb / twenty);
+    out_c[n] = g * xn;
+  }
+}
+
+torch::Tensor compressor_forward_cuda(
+    const torch::Tensor& x,
+    double threshold_db,
+    double inv_ratio,
+    double knee_db,
+    double makeup_db,
+    double attack_coeff,
+    double release_coeff,
+    double rms_coeff,
+    int detector) {
+
+  TORCH_CHECK(x.is_cuda(), "compressor_forward_cuda: input must be on CUDA");
+
+  auto x_cont = x.contiguous();
+  int64_t C, T;
+  if (x_cont.dim() == 1) {
+    C = 1;
+    T = x_cont.size(0);
+    x_cont = x_cont.unsqueeze(0);
+  } else {
+    C = x_cont.size(0);
+    T = x_cont.size(1);
+  }
+
+  auto output = torch::empty_like(x_cont);
+
+  const int threads = 128;
+  const int blocks = (static_cast<int>(C) + threads - 1) / threads;
+  const auto stream = c10::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_FLOATING_TYPES(x_cont.scalar_type(), "compressor_forward_cuda", [&] {
+    compressor_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+        x_cont.data_ptr<scalar_t>(), output.data_ptr<scalar_t>(),
+        static_cast<scalar_t>(threshold_db), static_cast<scalar_t>(inv_ratio),
+        static_cast<scalar_t>(knee_db), static_cast<scalar_t>(makeup_db),
+        static_cast<scalar_t>(attack_coeff), static_cast<scalar_t>(release_coeff),
+        static_cast<scalar_t>(rms_coeff), detector,
+        static_cast<int>(C), static_cast<int>(T));
+  });
+
+  if (x.dim() == 1) {
+    return output.squeeze(0);
+  }
+  return output;
+}
+
+}  // namespace torchfx

--- a/src/torchfx/_csrc/cuda/expander_forward.cu
+++ b/src/torchfx/_csrc/cuda/expander_forward.cu
@@ -1,0 +1,120 @@
+#include <torch/torch.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <c10/cuda/CUDAStream.h>
+#include "torchfx/expander_kernel.h"
+
+// Downward expander / noise gate with a decoupled peak detector. One thread per
+// channel, each walking its own time series sequentially (the ballistics are a
+// nonlinear recurrence — same topology as the sequential biquad / compressor).
+// Templated on scalar_t so a float32 input runs natively in FP32. See
+// expander_kernel.h for the math.
+
+namespace torchfx {
+
+template <typename scalar_t>
+__global__ void expander_kernel(
+    const scalar_t* __restrict__ input,
+    scalar_t* __restrict__ output,
+    scalar_t threshold_db,
+    scalar_t slope,
+    scalar_t knee_db,
+    scalar_t floor_db,
+    scalar_t attack_coeff,
+    scalar_t release_coeff,
+    scalar_t rms_coeff,
+    int detector,
+    int C,
+    int T) {
+
+  const int channel = blockIdx.x * blockDim.x + threadIdx.x;
+  if (channel >= C) return;
+
+  const scalar_t* in_c = input + static_cast<int64_t>(channel) * T;
+  scalar_t* out_c = output + static_cast<int64_t>(channel) * T;
+
+  const scalar_t eps = static_cast<scalar_t>(1e-12);
+  const scalar_t one = static_cast<scalar_t>(1);
+  const scalar_t two = static_cast<scalar_t>(2);
+  const scalar_t twenty = static_cast<scalar_t>(20);
+
+  scalar_t y1 = 0, yL = 0, ms = 0;
+  for (int n = 0; n < T; ++n) {
+    const scalar_t xn = in_c[n];
+
+    scalar_t rect;
+    if (detector == 1) {  // RMS
+      ms = rms_coeff * ms + (one - rms_coeff) * xn * xn;
+      rect = sqrt(ms);
+    } else {  // peak
+      rect = fabs(xn);
+    }
+
+    y1 = fmax(rect, release_coeff * y1);                 // release max-hold
+    yL = attack_coeff * yL + (one - attack_coeff) * y1;  // attack one-pole
+
+    const scalar_t L = twenty * log10(fmax(yL, eps));
+    const scalar_t over = L - threshold_db;
+    scalar_t gdb;
+    if (knee_db > scalar_t(0) && two * fabs(over) <= knee_db) {
+      const scalar_t t = over - knee_db / two;
+      gdb = -slope * t * t / (two * knee_db);
+    } else if (over < scalar_t(0)) {
+      gdb = slope * over;
+    } else {
+      gdb = scalar_t(0);
+    }
+    gdb = fmax(gdb, floor_db);
+
+    const scalar_t g = pow(static_cast<scalar_t>(10), gdb / twenty);
+    out_c[n] = g * xn;
+  }
+}
+
+torch::Tensor expander_forward_cuda(
+    const torch::Tensor& x,
+    double threshold_db,
+    double slope,
+    double knee_db,
+    double floor_db,
+    double attack_coeff,
+    double release_coeff,
+    double rms_coeff,
+    int detector) {
+
+  TORCH_CHECK(x.is_cuda(), "expander_forward_cuda: input must be on CUDA");
+
+  auto x_cont = x.contiguous();
+  int64_t C, T;
+  if (x_cont.dim() == 1) {
+    C = 1;
+    T = x_cont.size(0);
+    x_cont = x_cont.unsqueeze(0);
+  } else {
+    C = x_cont.size(0);
+    T = x_cont.size(1);
+  }
+
+  auto output = torch::empty_like(x_cont);
+
+  const int threads = 128;
+  const int blocks = (static_cast<int>(C) + threads - 1) / threads;
+  const auto stream = c10::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_FLOATING_TYPES(x_cont.scalar_type(), "expander_forward_cuda", [&] {
+    expander_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+        x_cont.data_ptr<scalar_t>(), output.data_ptr<scalar_t>(),
+        static_cast<scalar_t>(threshold_db), static_cast<scalar_t>(slope),
+        static_cast<scalar_t>(knee_db), static_cast<scalar_t>(floor_db),
+        static_cast<scalar_t>(attack_coeff), static_cast<scalar_t>(release_coeff),
+        static_cast<scalar_t>(rms_coeff), detector,
+        static_cast<int>(C), static_cast<int>(T));
+  });
+
+  if (x.dim() == 1) {
+    return output.squeeze(0);
+  }
+  return output;
+}
+
+}  // namespace torchfx

--- a/src/torchfx/_csrc/cuda/limiter_forward.cu
+++ b/src/torchfx/_csrc/cuda/limiter_forward.cu
@@ -1,0 +1,90 @@
+#include <torch/torch.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <c10/cuda/CUDAStream.h>
+#include "torchfx/limiter_kernel.h"
+
+// Look-ahead brick-wall limiter (gain stage). The look-ahead windowed peak is precomputed;
+// this runs the sequential gain recurrence, one thread per channel. Templated on scalar_t
+// so a float32 input runs natively in FP32. See limiter_kernel.h for the math.
+
+namespace torchfx {
+
+template <typename scalar_t>
+__global__ void limiter_kernel(
+    const scalar_t* __restrict__ input,
+    const scalar_t* __restrict__ peak_env,
+    scalar_t* __restrict__ output,
+    scalar_t threshold_lin,
+    scalar_t attack_coeff,
+    scalar_t release_coeff,
+    int C,
+    int T) {
+
+  const int channel = blockIdx.x * blockDim.x + threadIdx.x;
+  if (channel >= C) return;
+
+  const scalar_t* in_c = input + static_cast<int64_t>(channel) * T;
+  const scalar_t* peak_c = peak_env + static_cast<int64_t>(channel) * T;
+  scalar_t* out_c = output + static_cast<int64_t>(channel) * T;
+
+  const scalar_t eps = static_cast<scalar_t>(1e-12);
+  const scalar_t one = static_cast<scalar_t>(1);
+
+  scalar_t g = one;
+  for (int n = 0; n < T; ++n) {
+    const scalar_t gr = fmin(one, threshold_lin / fmax(peak_c[n], eps));
+    if (gr < g) {
+      g = attack_coeff * g + (one - attack_coeff) * gr;
+    } else {
+      g = release_coeff * g + (one - release_coeff) * gr;
+    }
+    const scalar_t clamp = threshold_lin / fmax(fabs(in_c[n]), eps);
+    const scalar_t g_out = fmin(g, clamp);
+    out_c[n] = g_out * in_c[n];
+  }
+}
+
+torch::Tensor limiter_forward_cuda(
+    const torch::Tensor& x,
+    const torch::Tensor& peak_env,
+    double threshold_lin,
+    double attack_coeff,
+    double release_coeff) {
+
+  TORCH_CHECK(x.is_cuda(), "limiter_forward_cuda: input must be on CUDA");
+  TORCH_CHECK(x.sizes() == peak_env.sizes(), "limiter_forward_cuda: x and peak_env must match");
+
+  auto x_cont = x.contiguous();
+  auto peak_cont = peak_env.contiguous();
+  int64_t C, T;
+  if (x_cont.dim() == 1) {
+    C = 1;
+    T = x_cont.size(0);
+    x_cont = x_cont.unsqueeze(0);
+    peak_cont = peak_cont.unsqueeze(0);
+  } else {
+    C = x_cont.size(0);
+    T = x_cont.size(1);
+  }
+
+  auto output = torch::empty_like(x_cont);
+
+  const int threads = 128;
+  const int blocks = (static_cast<int>(C) + threads - 1) / threads;
+  const auto stream = c10::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_FLOATING_TYPES(x_cont.scalar_type(), "limiter_forward_cuda", [&] {
+    limiter_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+        x_cont.data_ptr<scalar_t>(), peak_cont.data_ptr<scalar_t>(), output.data_ptr<scalar_t>(),
+        static_cast<scalar_t>(threshold_lin), static_cast<scalar_t>(attack_coeff),
+        static_cast<scalar_t>(release_coeff), static_cast<int>(C), static_cast<int>(T));
+  });
+
+  if (x.dim() == 1) {
+    return output.squeeze(0);
+  }
+  return output;
+}
+
+}  // namespace torchfx

--- a/src/torchfx/_csrc/cuda/parallel_scan.cu
+++ b/src/torchfx/_csrc/cuda/parallel_scan.cu
@@ -294,6 +294,114 @@ __global__ void fused_sequential_kernel(
 }
 
 // ============================================================
+// Single-pass scan with decoupled look-back (paper C1 / Epic 4.6).
+//
+// Replaces forcing_kernel + prefix_scan_phase1/2/3 with ONE launch per section:
+// each tile computes its forcing inline, runs the intra-tile Blelloch scan, then
+// gets its inter-tile (exclusive) prefix by decoupled look-back (Merrill-Garland /
+// CUB) over predecessor tiles of the same channel — no phase-2 scan, no phase-3
+// recompute.
+//
+// Forward progress: an atomic per-(section, channel) tile dispenser hands out
+// logical tile ids in execution order, so a block only ever waits on lower tile ids
+// held by already-running blocks (deadlock-free even when num_blocks exceeds the
+// number of resident blocks).
+//
+// Status is epoch-tagged (epoch = section index) so the per-forward status /
+// aggregate / prefix scratch is reused across all sections after a single up-front
+// zeroing of `status` (no per-section reset): status = (epoch << 2) | state, with
+// state in {0 empty, 1 aggregate-ready, 2 prefix-ready}. A stale value from an
+// earlier section carries an older epoch and reads as not-ready.
+// ============================================================
+
+constexpr int ST_EMPTY = 0;
+constexpr int ST_AGG = 1;
+constexpr int ST_PREFIX = 2;
+
+__device__ __forceinline__ int st_tag(int epoch, int state) { return (epoch << 2) | state; }
+
+template <typename scalar_t>
+__global__ void fused_scan_kernel(
+    const scalar_t* __restrict__ x,      // [C, T]
+    const scalar_t* __restrict__ sx,     // [C, 2] = {x[-1], x[-2]}
+    const scalar_t* __restrict__ sy,     // [C, 2] = {y[-1], y[-2]}
+    scalar_t b0, scalar_t b1, scalar_t b2,
+    scalar_t a1, scalar_t a2,
+    scalar_t* __restrict__ y,            // [C, T]
+    int* __restrict__ status,            // [C, num_blocks] epoch-tagged
+    Mat3x3<scalar_t>* __restrict__ aggregate,  // [C, num_blocks]
+    Mat3x3<scalar_t>* __restrict__ prefix,     // [C, num_blocks]
+    int* __restrict__ tile_counter,      // [C] dispenser for THIS section
+    int epoch, int T, int num_blocks) {
+
+  const int channel = blockIdx.y;
+  const int tid = threadIdx.x;
+
+  // Atomic tile dispenser: logical tile id in execution order (forward progress).
+  __shared__ int s_tile;
+  if (tid == 0) s_tile = atomicAdd(&tile_counter[channel], 1);
+  __syncthreads();
+  const int kt = s_tile;
+  if (kt >= num_blocks) return;  // safety; grid has exactly num_blocks blocks/channel
+
+  const int tile_start = kt * BLOCK_SIZE;
+  const int n = tile_start + tid;
+  const int base = channel * num_blocks;
+
+  __shared__ Mat3x3<scalar_t> sdata[BLOCK_SIZE];
+
+  // 1. Forcing inline -> per-sample matrix (identity for out-of-range samples).
+  Mat3x3<scalar_t> my_mat;
+  if (n < T) {
+    const scalar_t xn = x[channel * T + n];
+    scalar_t xn1, xn2;
+    if (n >= 2) { xn1 = x[channel * T + n - 1]; xn2 = x[channel * T + n - 2]; }
+    else if (n == 1) { xn1 = x[channel * T + 0]; xn2 = sx[channel * 2 + 0]; }
+    else { xn1 = sx[channel * 2 + 0]; xn2 = sx[channel * 2 + 1]; }
+    const scalar_t fn = b0 * xn + b1 * xn1 + b2 * xn2;
+    my_mat.m[0] = -a1; my_mat.m[1] = -a2; my_mat.m[2] = fn;
+    my_mat.m[3] = scalar_t(1); my_mat.m[4] = scalar_t(0); my_mat.m[5] = scalar_t(0);
+  } else {
+    my_mat = mat_identity<scalar_t>();
+  }
+  sdata[tid] = my_mat;
+  __syncthreads();
+
+  // 2. Intra-tile inclusive scan; sdata[tid] = local inclusive prefix, block_total = aggregate.
+  Mat3x3<scalar_t> block_total = blelloch_inclusive_scan<scalar_t>(sdata, my_mat, tid);
+
+  // 3. Thread 0: decoupled look-back -> exclusive (inter-tile) prefix.
+  __shared__ Mat3x3<scalar_t> s_excl;
+  if (tid == 0) {
+    Mat3x3<scalar_t> excl = mat_identity<scalar_t>();
+    if (kt > 0) {
+      aggregate[base + kt] = block_total;
+      __threadfence();
+      atomicExch(&status[base + kt], st_tag(epoch, ST_AGG));
+      for (int j = kt - 1; j >= 0; --j) {
+        int s;
+        do { s = atomicAdd(&status[base + j], 0); }  // forced fresh read
+        while (!((s >> 2) == epoch && (s & 3) >= ST_AGG));
+        __threadfence();
+        if ((s & 3) == ST_PREFIX) { excl = mat_mul<scalar_t>(excl, prefix[base + j]); break; }
+        excl = mat_mul<scalar_t>(excl, aggregate[base + j]);
+      }
+    }
+    prefix[base + kt] = mat_mul<scalar_t>(block_total, excl);
+    __threadfence();
+    atomicExch(&status[base + kt], st_tag(epoch, ST_PREFIX));
+    s_excl = excl;
+  }
+  __syncthreads();
+
+  // 4. Apply exclusive prefix + initial state -> output.
+  if (n < T) {
+    Mat3x3<scalar_t> total = mat_mul<scalar_t>(sdata[tid], s_excl);
+    y[channel * T + n] = extract_y<scalar_t>(total, sy[channel * 2 + 0], sy[channel * 2 + 1]);
+  }
+}
+
+// ============================================================
 // Custom CUDA kernel for 3-tap FIR with state prepend.
 // Fuses the cat + conv1d into a single kernel launch, eliminating
 // ~5 intermediate tensor operations and cuDNN dispatch overhead.
@@ -456,12 +564,15 @@ std::tuple<torch::Tensor, torch::Tensor> parallel_biquad_scan(
 //
 // Replaces the per-section (compute_forcing_into + parallel_biquad_scan_into) pair
 // with a single fused launch:
-//   - T <= threshold : fused_sequential_kernel (forcing inline)        -- 1 launch.
-//   - T  > threshold : single-pass decoupled-look-back scan (inline)   -- 1 launch
-//                      (NOT YET WIRED — falls back to the 3-phase path).
+//   - T <= threshold : fused_sequential_kernel (forcing inline)       -- 1 launch.
+//   - T  > threshold : single-pass decoupled-look-back scan (inline)  -- 1 launch.
 // Reads state_x (for forcing) and state_y (recurrence init); writes y_out. The
 // caller updates the state tails in place afterwards (unchanged from the 3-phase
 // path). All launches are on the current stream for CUDA-graph safety.
+//
+// status / aggregate / prefix are per-forward scratch reused across all sections
+// (gated by the epoch tag = section index); `tile_counter` is this section's [C]
+// dispenser. `status` and `tile_counter` must be zero before the FIRST section.
 void fused_sos_scan_into(
     const torch::Tensor& x,
     double b0, double b1, double b2,
@@ -470,8 +581,11 @@ void fused_sos_scan_into(
     const torch::Tensor& state_y,
     int threshold,
     torch::Tensor& y_out,
-    torch::Tensor& f_scratch,
-    torch::Tensor& block_agg) {
+    torch::Tensor& status,
+    torch::Tensor& aggregate,
+    torch::Tensor& prefix,
+    torch::Tensor& tile_counter,
+    int epoch) {
 
   auto x_c = x.contiguous();
   auto sx = state_x.contiguous();
@@ -490,9 +604,19 @@ void fused_sos_scan_into(
           y_out.data_ptr<scalar_t>(), static_cast<int>(T), static_cast<int>(C));
     });
   } else {
-    // Increment B will replace this with the single-pass fused_scan_kernel.
-    compute_forcing_into(x_c, b0, b1, b2, sx, f_scratch);
-    parallel_biquad_scan_into(f_scratch, a1, a2, sy, threshold, y_out, block_agg);
+    const int num_blocks = (static_cast<int>(T) + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    dim3 grid(num_blocks, static_cast<int>(C));
+    AT_DISPATCH_FLOATING_TYPES(x_c.scalar_type(), "fused_scan", [&] {
+      auto agg_ptr = reinterpret_cast<Mat3x3<scalar_t>*>(aggregate.data_ptr<scalar_t>());
+      auto pre_ptr = reinterpret_cast<Mat3x3<scalar_t>*>(prefix.data_ptr<scalar_t>());
+      fused_scan_kernel<scalar_t><<<grid, BLOCK_SIZE, 0, stream>>>(
+          x_c.data_ptr<scalar_t>(), sx.data_ptr<scalar_t>(), sy.data_ptr<scalar_t>(),
+          static_cast<scalar_t>(b0), static_cast<scalar_t>(b1), static_cast<scalar_t>(b2),
+          static_cast<scalar_t>(a1), static_cast<scalar_t>(a2),
+          y_out.data_ptr<scalar_t>(),
+          status.data_ptr<int>(), agg_ptr, pre_ptr, tile_counter.data_ptr<int>(),
+          epoch, static_cast<int>(T), num_blocks);
+    });
   }
 }
 

--- a/src/torchfx/_csrc/cuda/parallel_scan.cu
+++ b/src/torchfx/_csrc/cuda/parallel_scan.cu
@@ -260,6 +260,40 @@ __global__ void sequential_biquad_kernel(
 }
 
 // ============================================================
+// Fused sequential kernel: FIR forcing + IIR recurrence in ONE launch.
+// Folds the forcing pass into the sequential biquad recurrence so the small-T
+// branch is a single kernel (was forcing_kernel + sequential_biquad_kernel).
+// Each thread handles one channel; multiple channels per block for occupancy.
+// ============================================================
+template <typename scalar_t>
+__global__ void fused_sequential_kernel(
+    const scalar_t* __restrict__ x,     // [C, T]
+    const scalar_t* __restrict__ sx,    // [C, 2] = {x[-1], x[-2]}
+    const scalar_t* __restrict__ sy,    // [C, 2] = {y[-1], y[-2]}
+    scalar_t b0, scalar_t b1, scalar_t b2,
+    scalar_t a1, scalar_t a2,
+    scalar_t* __restrict__ y,           // [C, T]
+    int T, int C) {
+
+  const int channel = blockIdx.x * blockDim.x + threadIdx.x;
+  if (channel >= C) return;
+
+  scalar_t x_m1 = sx[channel * 2 + 0];
+  scalar_t x_m2 = sx[channel * 2 + 1];
+  scalar_t y_m1 = sy[channel * 2 + 0];
+  scalar_t y_m2 = sy[channel * 2 + 1];
+
+  for (int n = 0; n < T; ++n) {
+    const scalar_t xn = x[channel * T + n];
+    const scalar_t fn = b0 * xn + b1 * x_m1 + b2 * x_m2;  // forcing, inline
+    const scalar_t yn = fn - a1 * y_m1 - a2 * y_m2;       // recurrence
+    y[channel * T + n] = yn;
+    x_m2 = x_m1; x_m1 = xn;
+    y_m2 = y_m1; y_m1 = yn;
+  }
+}
+
+// ============================================================
 // Custom CUDA kernel for 3-tap FIR with state prepend.
 // Fuses the cat + conv1d into a single kernel launch, eliminating
 // ~5 intermediate tensor operations and cuDNN dispatch overhead.
@@ -416,6 +450,50 @@ std::tuple<torch::Tensor, torch::Tensor> parallel_biquad_scan(
       torch::zeros({C, 1}, y.options());
   auto new_st = torch::cat({y_last, y_prev}, 1);  // [C, 2]
   return std::make_tuple(y, new_st);
+}
+
+// Fused per-section SOS path: forcing folded into the scan.
+//
+// Replaces the per-section (compute_forcing_into + parallel_biquad_scan_into) pair
+// with a single fused launch:
+//   - T <= threshold : fused_sequential_kernel (forcing inline)        -- 1 launch.
+//   - T  > threshold : single-pass decoupled-look-back scan (inline)   -- 1 launch
+//                      (NOT YET WIRED — falls back to the 3-phase path).
+// Reads state_x (for forcing) and state_y (recurrence init); writes y_out. The
+// caller updates the state tails in place afterwards (unchanged from the 3-phase
+// path). All launches are on the current stream for CUDA-graph safety.
+void fused_sos_scan_into(
+    const torch::Tensor& x,
+    double b0, double b1, double b2,
+    double a1, double a2,
+    const torch::Tensor& state_x,
+    const torch::Tensor& state_y,
+    int threshold,
+    torch::Tensor& y_out,
+    torch::Tensor& f_scratch,
+    torch::Tensor& block_agg) {
+
+  auto x_c = x.contiguous();
+  auto sx = state_x.contiguous();
+  auto sy = state_y.contiguous();
+  const int64_t C = x_c.size(0);
+  const int64_t T = x_c.size(1);
+  const auto stream = c10::cuda::getCurrentCUDAStream();
+
+  if (T <= threshold) {
+    const int blocks = (static_cast<int>(C) + SEQ_THREADS_PER_BLOCK - 1) / SEQ_THREADS_PER_BLOCK;
+    AT_DISPATCH_FLOATING_TYPES(x_c.scalar_type(), "fused_sequential", [&] {
+      fused_sequential_kernel<scalar_t><<<blocks, SEQ_THREADS_PER_BLOCK, 0, stream>>>(
+          x_c.data_ptr<scalar_t>(), sx.data_ptr<scalar_t>(), sy.data_ptr<scalar_t>(),
+          static_cast<scalar_t>(b0), static_cast<scalar_t>(b1), static_cast<scalar_t>(b2),
+          static_cast<scalar_t>(a1), static_cast<scalar_t>(a2),
+          y_out.data_ptr<scalar_t>(), static_cast<int>(T), static_cast<int>(C));
+    });
+  } else {
+    // Increment B will replace this with the single-pass fused_scan_kernel.
+    compute_forcing_into(x_c, b0, b1, b2, sx, f_scratch);
+    parallel_biquad_scan_into(f_scratch, a1, a2, sy, threshold, y_out, block_agg);
+  }
 }
 
 }  // namespace torchfx

--- a/src/torchfx/_csrc/cuda/parallel_scan.cu
+++ b/src/torchfx/_csrc/cuda/parallel_scan.cu
@@ -294,7 +294,7 @@ __global__ void fused_sequential_kernel(
 }
 
 // ============================================================
-// Single-pass scan with decoupled look-back (paper C1 / Epic 4.6).
+// Single-pass scan with decoupled look-back (Epic 4.6).
 //
 // Replaces forcing_kernel + prefix_scan_phase1/2/3 with ONE launch per section:
 // each tile computes its forcing inline, runs the intra-tile Blelloch scan, then

--- a/src/torchfx/_csrc/cuda/parallel_scan.cu
+++ b/src/torchfx/_csrc/cuda/parallel_scan.cu
@@ -402,6 +402,35 @@ __global__ void fused_scan_kernel(
 }
 
 // ============================================================
+// Fused state update: write the new DF1 state tails in one launch (one thread per
+// channel), replacing the per-section narrow/select/copy_ ops. Runs AFTER the scan
+// kernel (separate launch) so y_out / xin are complete — no race with the in-place
+// state buffers. Matches the 3-phase path's semantics exactly, including the T==1
+// edge (y[-2] := 0; x history shifts).
+// ============================================================
+template <typename scalar_t>
+__global__ void state_update_kernel(
+    const scalar_t* __restrict__ y,    // [C, T] this section's output
+    const scalar_t* __restrict__ xin,  // [C, T] this section's input
+    scalar_t* __restrict__ sx,         // [C, 2] in/out: {x[-1], x[-2]}
+    scalar_t* __restrict__ sy,         // [C, 2] in/out: {y[-1], y[-2]}
+    int T, int C) {
+  const int c = blockIdx.x * blockDim.x + threadIdx.x;
+  if (c >= C) return;
+  if (T >= 1) {
+    sy[c * 2 + 0] = y[c * T + (T - 1)];
+    sy[c * 2 + 1] = (T >= 2) ? y[c * T + (T - 2)] : scalar_t(0);
+  }
+  if (T >= 2) {
+    sx[c * 2 + 0] = xin[c * T + (T - 1)];
+    sx[c * 2 + 1] = xin[c * T + (T - 2)];
+  } else if (T == 1) {
+    sx[c * 2 + 1] = sx[c * 2 + 0];   // x[-2] <- old x[-1]
+    sx[c * 2 + 0] = xin[c * T + 0];  // x[-1] <- x[0]
+  }
+}
+
+// ============================================================
 // Custom CUDA kernel for 3-tap FIR with state prepend.
 // Fuses the cat + conv1d into a single kernel launch, eliminating
 // ~5 intermediate tensor operations and cuDNN dispatch overhead.
@@ -618,6 +647,17 @@ void fused_sos_scan_into(
           epoch, static_cast<int>(T), num_blocks);
     });
   }
+
+  // Fused state update (one launch, both branches): the caller skips its copy_ block.
+  // sx/sy share storage with the caller's persistent [K,C,2] state views, so this
+  // updates them in place after the scan has read the old state.
+  const int su_blocks = (static_cast<int>(C) + SEQ_THREADS_PER_BLOCK - 1) / SEQ_THREADS_PER_BLOCK;
+  AT_DISPATCH_FLOATING_TYPES(x_c.scalar_type(), "fused_state_update", [&] {
+    state_update_kernel<scalar_t><<<su_blocks, SEQ_THREADS_PER_BLOCK, 0, stream>>>(
+        y_out.data_ptr<scalar_t>(), x_c.data_ptr<scalar_t>(),
+        sx.data_ptr<scalar_t>(), sy.data_ptr<scalar_t>(),
+        static_cast<int>(T), static_cast<int>(C));
+  });
 }
 
 }  // namespace torchfx

--- a/src/torchfx/_csrc/cuda/reverb_forward.cu
+++ b/src/torchfx/_csrc/cuda/reverb_forward.cu
@@ -1,0 +1,147 @@
+#include <torch/torch.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <c10/cuda/CUDAStream.h>
+#include <algorithm>
+#include <cmath>
+#include "torchfx/reverb_kernel.h"
+
+// Freeverb-style reverb, one thread per channel (sequential over time, ring buffers in a
+// per-channel scratch block). Templated on scalar_t so float32 runs natively in FP32. See
+// reverb_kernel.h for the math.
+
+namespace torchfx {
+
+struct ReverbDims {
+  int comb_len[kReverbNumCombs];
+  int comb_off[kReverbNumCombs];
+  int ap_len[kReverbNumAllpass];
+  int ap_off[kReverbNumAllpass];
+  int comb_total;
+  int total;
+};
+
+template <typename scalar_t>
+__global__ void reverb_kernel(
+    const scalar_t* __restrict__ input,
+    scalar_t* __restrict__ output,
+    scalar_t* __restrict__ scratch,
+    int C,
+    int T,
+    ReverbDims dims,
+    scalar_t feedback,
+    scalar_t damp,
+    scalar_t input_gain,
+    scalar_t allpass_fb,
+    scalar_t wet,
+    scalar_t dry) {
+
+  const int c = blockIdx.x * blockDim.x + threadIdx.x;
+  if (c >= C) return;
+
+  const scalar_t one = static_cast<scalar_t>(1);
+  const scalar_t* in_c = input + static_cast<int64_t>(c) * T;
+  scalar_t* out_c = output + static_cast<int64_t>(c) * T;
+  scalar_t* buf = scratch + static_cast<int64_t>(c) * dims.total;
+
+  scalar_t fstore[kReverbNumCombs];
+  int cidx[kReverbNumCombs];
+  int aidx[kReverbNumAllpass];
+#pragma unroll
+  for (int i = 0; i < kReverbNumCombs; ++i) {
+    fstore[i] = 0;
+    cidx[i] = 0;
+  }
+#pragma unroll
+  for (int j = 0; j < kReverbNumAllpass; ++j) aidx[j] = 0;
+
+  for (int n = 0; n < T; ++n) {
+    const scalar_t xn = in_c[n];
+    const scalar_t inp = xn * input_gain;
+    scalar_t acc = 0;
+
+#pragma unroll
+    for (int i = 0; i < kReverbNumCombs; ++i) {
+      scalar_t* cb = buf + dims.comb_off[i];
+      const scalar_t bo = cb[cidx[i]];
+      fstore[i] = bo * (one - damp) + fstore[i] * damp;
+      cb[cidx[i]] = inp + fstore[i] * feedback;
+      if (++cidx[i] >= dims.comb_len[i]) cidx[i] = 0;
+      acc += bo;
+    }
+#pragma unroll
+    for (int j = 0; j < kReverbNumAllpass; ++j) {
+      scalar_t* ab = buf + dims.comb_total + dims.ap_off[j];
+      const scalar_t bo = ab[aidx[j]];
+      ab[aidx[j]] = acc + bo * allpass_fb;
+      acc = bo - acc;
+      if (++aidx[j] >= dims.ap_len[j]) aidx[j] = 0;
+    }
+    out_c[n] = xn * dry + acc * wet;
+  }
+}
+
+torch::Tensor reverb_forward_cuda(
+    const torch::Tensor& x,
+    int fs,
+    double feedback,
+    double damp,
+    double input_gain,
+    double allpass_fb,
+    double wet,
+    double dry) {
+
+  TORCH_CHECK(x.is_cuda(), "reverb_forward_cuda: input must be on CUDA");
+
+  auto x_cont = x.contiguous();
+  int64_t C, T;
+  if (x_cont.dim() == 1) {
+    C = 1;
+    T = x_cont.size(0);
+    x_cont = x_cont.unsqueeze(0);
+  } else {
+    C = x_cont.size(0);
+    T = x_cont.size(1);
+  }
+
+  ReverbDims dims;
+  dims.comb_total = 0;
+  for (int i = 0; i < kReverbNumCombs; ++i) {
+    const int len =
+        std::max<int>(1, static_cast<int>(std::lround(kReverbCombTuning[i] * fs / kReverbTuningFs)));
+    dims.comb_len[i] = len;
+    dims.comb_off[i] = dims.comb_total;
+    dims.comb_total += len;
+  }
+  int ap_total = 0;
+  for (int j = 0; j < kReverbNumAllpass; ++j) {
+    const int len = std::max<int>(
+        1, static_cast<int>(std::lround(kReverbAllpassTuning[j] * fs / kReverbTuningFs)));
+    dims.ap_len[j] = len;
+    dims.ap_off[j] = ap_total;
+    ap_total += len;
+  }
+  dims.total = dims.comb_total + ap_total;
+
+  auto output = torch::empty_like(x_cont);
+  auto scratch = torch::zeros({C, static_cast<int64_t>(dims.total)}, x_cont.options());
+
+  const int threads = 128;
+  const int blocks = (static_cast<int>(C) + threads - 1) / threads;
+  const auto stream = c10::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_FLOATING_TYPES(x_cont.scalar_type(), "reverb_forward_cuda", [&] {
+    reverb_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+        x_cont.data_ptr<scalar_t>(), output.data_ptr<scalar_t>(), scratch.data_ptr<scalar_t>(),
+        static_cast<int>(C), static_cast<int>(T), dims, static_cast<scalar_t>(feedback),
+        static_cast<scalar_t>(damp), static_cast<scalar_t>(input_gain),
+        static_cast<scalar_t>(allpass_fb), static_cast<scalar_t>(wet), static_cast<scalar_t>(dry));
+  });
+
+  if (x.dim() == 1) {
+    return output.squeeze(0);
+  }
+  return output;
+}
+
+}  // namespace torchfx

--- a/src/torchfx/_csrc/include/torchfx/compressor_kernel.h
+++ b/src/torchfx/_csrc/include/torchfx/compressor_kernel.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <torch/types.h>
+
+namespace torchfx {
+
+// Feed-forward dynamic-range compressor with a decoupled peak detector.
+//
+// Per channel, sequentially over time n:
+//   rect = |x[n]|                              (detector=0, peak)
+//   ms   = rms_coeff*ms + (1-rms_coeff)*x^2;  rect = sqrt(ms)  (detector=1, rms)
+//   y1   = max(rect, release_coeff * y1)       (release max-hold)
+//   yL   = attack_coeff*yL + (1-attack_coeff)*y1   (attack one-pole)
+//   L    = 20*log10(max(yL, eps))
+//   gain curve (threshold_db, inv_ratio, knee_db) -> Lsc
+//   g    = 10^((Lsc - L + makeup_db)/20);  y[n] = g * x[n]
+//
+// `inv_ratio` is 1/ratio (0 for an infinite-ratio limiter, avoiding inf math).
+torch::Tensor compressor_forward_cuda(
+    const torch::Tensor& x,
+    double threshold_db,
+    double inv_ratio,
+    double knee_db,
+    double makeup_db,
+    double attack_coeff,
+    double release_coeff,
+    double rms_coeff,
+    int detector);
+
+}  // namespace torchfx

--- a/src/torchfx/_csrc/include/torchfx/expander_kernel.h
+++ b/src/torchfx/_csrc/include/torchfx/expander_kernel.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <torch/types.h>
+
+namespace torchfx {
+
+// Downward expander / noise gate with a decoupled peak detector — the mirror image
+// of the compressor: gain is reduced *below* the threshold instead of above it.
+//
+// Per channel, sequentially over time n (detector identical to the compressor):
+//   rect = |x[n]|                              (detector=0, peak)
+//   ms   = rms_coeff*ms + (1-rms_coeff)*x^2;  rect = sqrt(ms)  (detector=1, rms)
+//   y1   = max(rect, release_coeff * y1)       (release max-hold)
+//   yL   = attack_coeff*yL + (1-attack_coeff)*y1   (attack one-pole)
+//   L    = 20*log10(max(yL, eps))
+//   over = L - threshold_db
+//   downward-expansion static curve (slope = ratio-1 >= 0, soft knee of width knee_db):
+//     |2*over| <= knee_db : gdb = -slope*(over - knee_db/2)^2 / (2*knee_db)   (knee)
+//     over < 0            : gdb = slope*over                                   (below thr)
+//     else               : gdb = 0                                            (above thr)
+//   gdb  = max(gdb, floor_db)   (floor_db <= 0 limits the maximum attenuation)
+//   g    = 10^(gdb/20);  y[n] = g * x[n]
+//
+// `slope` is ratio-1 (a large finite value stands in for an infinite-ratio gate, so the
+// kernel never does inf arithmetic); `floor_db` is the deepest attenuation in dB.
+torch::Tensor expander_forward_cuda(
+    const torch::Tensor& x,
+    double threshold_db,
+    double slope,
+    double knee_db,
+    double floor_db,
+    double attack_coeff,
+    double release_coeff,
+    double rms_coeff,
+    int detector);
+
+}  // namespace torchfx

--- a/src/torchfx/_csrc/include/torchfx/limiter_kernel.h
+++ b/src/torchfx/_csrc/include/torchfx/limiter_kernel.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <torch/types.h>
+
+namespace torchfx {
+
+// Look-ahead brick-wall peak limiter (gain stage).
+//
+// The look-ahead windowed peak `peak_env[n] = max(|x[n .. n+L]|)` is precomputed by the
+// Python layer (a vectorised forward max-pool), so this kernel only runs the sequential
+// gain recurrence — one channel per thread, over time n:
+//   gr    = min(1, threshold_lin / max(peak_env[n], eps))   (windowed target; look-ahead)
+//   g     = gr < g ? a_A*g + (1-a_A)*gr                       (attack: smooth ramp down)
+//                  : a_R*g + (1-a_R)*gr                        (release: smooth ramp up)
+//   g_out = min(g, threshold_lin / max(|x[n]|, eps))          (per-sample brick-wall clamp)
+//   y[n]  = g_out * x[n]
+//
+// The windowed target makes `g` start ramping down *before* a peak arrives (no transient
+// overshoot, no click), while the per-sample clamp guarantees |y[n]| <= threshold_lin — a
+// true brick wall — even though `g` itself is smoothed.
+torch::Tensor limiter_forward_cuda(
+    const torch::Tensor& x,
+    const torch::Tensor& peak_env,
+    double threshold_lin,
+    double attack_coeff,
+    double release_coeff);
+
+}  // namespace torchfx

--- a/src/torchfx/_csrc/include/torchfx/parallel_scan.h
+++ b/src/torchfx/_csrc/include/torchfx/parallel_scan.h
@@ -63,4 +63,20 @@ void parallel_biquad_scan_into(
     torch::Tensor& y_out,
     torch::Tensor& block_agg);
 
+// Fused per-section SOS path: the FIR forcing is folded into the scan so each
+// section is a single kernel launch (sequential branch done; parallel branch is
+// the single-pass decoupled-look-back scan). Reads ``state_x`` (forcing history)
+// and ``state_y`` (recurrence init); writes ``y_out``. ``f_scratch`` / ``block_agg``
+// are caller-owned reused buffers (the long-signal fallback still uses them).
+void fused_sos_scan_into(
+    const torch::Tensor& x,
+    double b0, double b1, double b2,
+    double a1, double a2,
+    const torch::Tensor& state_x,
+    const torch::Tensor& state_y,
+    int threshold,
+    torch::Tensor& y_out,
+    torch::Tensor& f_scratch,
+    torch::Tensor& block_agg);
+
 }  // namespace torchfx

--- a/src/torchfx/_csrc/include/torchfx/parallel_scan.h
+++ b/src/torchfx/_csrc/include/torchfx/parallel_scan.h
@@ -64,10 +64,12 @@ void parallel_biquad_scan_into(
     torch::Tensor& block_agg);
 
 // Fused per-section SOS path: the FIR forcing is folded into the scan so each
-// section is a single kernel launch (sequential branch done; parallel branch is
-// the single-pass decoupled-look-back scan). Reads ``state_x`` (forcing history)
-// and ``state_y`` (recurrence init); writes ``y_out``. ``f_scratch`` / ``block_agg``
-// are caller-owned reused buffers (the long-signal fallback still uses them).
+// section is a single kernel launch (sequential branch -> fused_sequential_kernel;
+// parallel branch -> single-pass decoupled-look-back fused_scan_kernel). Reads
+// ``state_x`` (forcing history) and ``state_y`` (recurrence init); writes ``y_out``.
+// ``status`` / ``aggregate`` / ``prefix`` are caller-owned per-forward scratch reused
+// across sections (gated by ``epoch`` = section index); ``tile_counter`` is this
+// section's [C] dispenser. ``status`` and ``tile_counter`` must be zero before s=0.
 void fused_sos_scan_into(
     const torch::Tensor& x,
     double b0, double b1, double b2,
@@ -76,7 +78,10 @@ void fused_sos_scan_into(
     const torch::Tensor& state_y,
     int threshold,
     torch::Tensor& y_out,
-    torch::Tensor& f_scratch,
-    torch::Tensor& block_agg);
+    torch::Tensor& status,
+    torch::Tensor& aggregate,
+    torch::Tensor& prefix,
+    torch::Tensor& tile_counter,
+    int epoch);
 
 }  // namespace torchfx

--- a/src/torchfx/_csrc/include/torchfx/reverb_kernel.h
+++ b/src/torchfx/_csrc/include/torchfx/reverb_kernel.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <torch/types.h>
+
+namespace torchfx {
+
+// Freeverb-style algorithmic reverb: per channel, 8 parallel low-pass-feedback comb
+// filters summed, then fed through 4 series all-pass diffusers, mixed wet/dry.
+//
+// Comb (i):  out = buf[idx]; store = out*(1-damp) + store*damp;
+//            buf[idx] = in*input_gain + store*feedback;  acc += out
+// Allpass(j): bo = buf[idx]; buf[idx] = acc + bo*allpass_fb;  acc = bo - acc
+// y[n] = x[n]*dry + acc*wet
+//
+// The classic Schroeder/Moorer comb tunings (at 44.1 kHz) scaled to the signal's `fs`;
+// ring buffers live in a zero-initialised scratch tensor, one contiguous block per
+// channel. State is per-call (not carried across forward() calls).
+
+// Comb / all-pass delay tunings in samples at 44.1 kHz (Freeverb defaults).
+constexpr int kReverbNumCombs = 8;
+constexpr int kReverbNumAllpass = 4;
+constexpr int kReverbCombTuning[kReverbNumCombs] = {1116, 1188, 1277, 1356,
+                                                    1422, 1491, 1557, 1617};
+constexpr int kReverbAllpassTuning[kReverbNumAllpass] = {556, 441, 341, 225};
+constexpr double kReverbTuningFs = 44100.0;
+
+torch::Tensor reverb_forward_cuda(
+    const torch::Tensor& x,
+    int fs,
+    double feedback,
+    double damp,
+    double input_gain,
+    double allpass_fb,
+    double wet,
+    double dry);
+
+}  // namespace torchfx

--- a/src/torchfx/_ops.py
+++ b/src/torchfx/_ops.py
@@ -446,3 +446,49 @@ def limiter_forward(
     if len(original_shape) == 2:
         return result_2d
     return result_2d.reshape(original_shape)
+
+
+def reverb_forward(
+    x: Tensor,
+    fs: int,
+    feedback: float,
+    damp: float,
+    input_gain: float,
+    allpass_fb: float,
+    wet: float,
+    dry: float,
+) -> Tensor:
+    """Dispatch the Freeverb-style reverb to the native kernel (CUDA or CPU).
+
+    Eight parallel low-pass-feedback comb filters and four series all-pass diffusers per
+    channel, with comb/all-pass tunings scaled to ``fs``. ``feedback`` and ``damp`` set the
+    decay length and high-frequency damping; ``wet``/``dry`` mix the result. Returns the
+    processed tensor with the input shape and dtype preserved.
+
+    """
+    if x.ndim < 1:
+        raise ValueError("Input tensor must have at least 1 dimension.")
+    if not x.is_floating_point():
+        raise TypeError("Input tensor must use a floating-point dtype.")
+
+    original_shape = x.shape
+    if x.ndim == 1:
+        x_2d = x.unsqueeze(0)
+    elif x.ndim == 2:
+        x_2d = x
+    else:
+        x_2d = x.reshape(-1, x.size(-1))
+
+    native_dtype = torch.float64 if x_2d.dtype == torch.float64 else torch.float32
+    x_native = x_2d if x_2d.dtype == native_dtype else x_2d.to(dtype=native_dtype)
+
+    result_native: Tensor = _ext.reverb_forward(
+        x_native, int(fs), feedback, damp, input_gain, allpass_fb, wet, dry
+    )
+    result_2d = result_native if result_native.dtype == x.dtype else result_native.to(dtype=x.dtype)
+
+    if len(original_shape) == 1:
+        return result_2d.squeeze(0)
+    if len(original_shape) == 2:
+        return result_2d
+    return result_2d.reshape(original_shape)

--- a/src/torchfx/_ops.py
+++ b/src/torchfx/_ops.py
@@ -276,3 +276,59 @@ def delay_line_forward(
     if len(original_shape) == 2:
         return result_2d
     return result_2d.reshape(original_shape)
+
+
+def compressor_forward(
+    x: Tensor,
+    threshold_db: float,
+    inv_ratio: float,
+    knee_db: float,
+    makeup_db: float,
+    attack_coeff: float,
+    release_coeff: float,
+    rms_coeff: float,
+    detector: int,
+) -> Tensor:
+    """Dispatch the compressor to the native kernel (CUDA or CPU).
+
+    Ballistics coefficients are precomputed by the caller. ``detector`` is 0 (peak)
+    or 1 (rms); ``inv_ratio`` is ``1 / ratio`` (0 for an infinite-ratio limiter, so
+    the kernel never does ``inf`` arithmetic). Returns the processed tensor with the
+    input shape and dtype preserved.
+
+    """
+    if x.ndim < 1:
+        raise ValueError("Input tensor must have at least 1 dimension.")
+    if not x.is_floating_point():
+        raise TypeError("Input tensor must use a floating-point dtype.")
+
+    original_shape = x.shape
+    if x.ndim == 1:
+        x_2d = x.unsqueeze(0)
+    elif x.ndim == 2:
+        x_2d = x
+    else:
+        x_2d = x.reshape(-1, x.size(-1))
+
+    # Keep native kernels on their supported dtypes (float16/bfloat16 -> float32).
+    native_dtype = torch.float64 if x_2d.dtype == torch.float64 else torch.float32
+    x_native = x_2d if x_2d.dtype == native_dtype else x_2d.to(dtype=native_dtype)
+
+    result_native: Tensor = _ext.compressor_forward(
+        x_native,
+        threshold_db,
+        inv_ratio,
+        knee_db,
+        makeup_db,
+        attack_coeff,
+        release_coeff,
+        rms_coeff,
+        detector,
+    )
+    result_2d = result_native if result_native.dtype == x.dtype else result_native.to(dtype=x.dtype)
+
+    if len(original_shape) == 1:
+        return result_2d.squeeze(0)
+    if len(original_shape) == 2:
+        return result_2d
+    return result_2d.reshape(original_shape)

--- a/src/torchfx/_ops.py
+++ b/src/torchfx/_ops.py
@@ -332,3 +332,60 @@ def compressor_forward(
     if len(original_shape) == 2:
         return result_2d
     return result_2d.reshape(original_shape)
+
+
+def expander_forward(
+    x: Tensor,
+    threshold_db: float,
+    slope: float,
+    knee_db: float,
+    floor_db: float,
+    attack_coeff: float,
+    release_coeff: float,
+    rms_coeff: float,
+    detector: int,
+) -> Tensor:
+    """Dispatch the downward expander / gate to the native kernel (CUDA or CPU).
+
+    Ballistics coefficients are precomputed by the caller. ``detector`` is 0 (peak)
+    or 1 (rms); ``slope`` is ``ratio - 1`` (a large finite value stands in for an
+    infinite-ratio gate, so the kernel never does ``inf`` arithmetic); ``floor_db`` is
+    the deepest attenuation in dB. Returns the processed tensor with the input shape
+    and dtype preserved.
+
+    """
+    if x.ndim < 1:
+        raise ValueError("Input tensor must have at least 1 dimension.")
+    if not x.is_floating_point():
+        raise TypeError("Input tensor must use a floating-point dtype.")
+
+    original_shape = x.shape
+    if x.ndim == 1:
+        x_2d = x.unsqueeze(0)
+    elif x.ndim == 2:
+        x_2d = x
+    else:
+        x_2d = x.reshape(-1, x.size(-1))
+
+    # Keep native kernels on their supported dtypes (float16/bfloat16 -> float32).
+    native_dtype = torch.float64 if x_2d.dtype == torch.float64 else torch.float32
+    x_native = x_2d if x_2d.dtype == native_dtype else x_2d.to(dtype=native_dtype)
+
+    result_native: Tensor = _ext.expander_forward(
+        x_native,
+        threshold_db,
+        slope,
+        knee_db,
+        floor_db,
+        attack_coeff,
+        release_coeff,
+        rms_coeff,
+        detector,
+    )
+    result_2d = result_native if result_native.dtype == x.dtype else result_native.to(dtype=x.dtype)
+
+    if len(original_shape) == 1:
+        return result_2d.squeeze(0)
+    if len(original_shape) == 2:
+        return result_2d
+    return result_2d.reshape(original_shape)

--- a/src/torchfx/_ops.py
+++ b/src/torchfx/_ops.py
@@ -389,3 +389,60 @@ def expander_forward(
     if len(original_shape) == 2:
         return result_2d
     return result_2d.reshape(original_shape)
+
+
+def limiter_forward(
+    x: Tensor,
+    threshold_lin: float,
+    attack_coeff: float,
+    release_coeff: float,
+    lookahead_samples: int,
+) -> Tensor:
+    """Dispatch the look-ahead brick-wall limiter to the native kernel (CUDA or CPU).
+
+    The look-ahead windowed peak ``peak_env[n] = max(|x[n .. n+L]|)`` is computed here
+    with a vectorised forward max-pool (so the gain is reduced *before* a peak arrives);
+    the native kernel then runs only the sequential gain recurrence (attack/release
+    smoothing plus a per-sample brick-wall clamp). ``threshold_lin`` is the linear
+    ceiling, ``lookahead_samples`` is ``L``. Returns the processed tensor with the input
+    shape and dtype preserved.
+
+    """
+    if x.ndim < 1:
+        raise ValueError("Input tensor must have at least 1 dimension.")
+    if not x.is_floating_point():
+        raise TypeError("Input tensor must use a floating-point dtype.")
+
+    original_shape = x.shape
+    if x.ndim == 1:
+        x_2d = x.unsqueeze(0)
+    elif x.ndim == 2:
+        x_2d = x
+    else:
+        x_2d = x.reshape(-1, x.size(-1))
+
+    native_dtype = torch.float64 if x_2d.dtype == torch.float64 else torch.float32
+    x_native = x_2d if x_2d.dtype == native_dtype else x_2d.to(dtype=native_dtype)
+
+    # Forward look-ahead windowed peak: max of |x| over [n, n+L]. Zero-pad the tail so the
+    # window shrinks gracefully at the end (zeros never raise the max).
+    abs_x = x_native.abs()
+    lookahead = max(0, int(lookahead_samples))
+    if lookahead > 0:
+        padded = torch.nn.functional.pad(abs_x, (0, lookahead))
+        peak_env = torch.nn.functional.max_pool1d(
+            padded.unsqueeze(0), kernel_size=lookahead + 1, stride=1
+        ).squeeze(0)
+    else:
+        peak_env = abs_x
+
+    result_native: Tensor = _ext.limiter_forward(
+        x_native, peak_env.contiguous(), threshold_lin, attack_coeff, release_coeff
+    )
+    result_2d = result_native if result_native.dtype == x.dtype else result_native.to(dtype=x.dtype)
+
+    if len(original_shape) == 1:
+        return result_2d.squeeze(0)
+    if len(original_shape) == 2:
+        return result_2d
+    return result_2d.reshape(original_shape)

--- a/src/torchfx/batch.py
+++ b/src/torchfx/batch.py
@@ -1,0 +1,123 @@
+"""Batched multi-signal processing in a single kernel launch.
+
+Processing many short signals one at a time underuses the GPU: a stereo file is two
+threads on a device with thousands of cores, and each file is its own kernel launch.
+:func:`batch_process` instead pads the signals to a common length, concatenates them
+along the channel dimension into one ``(sum_channels, max_samples)`` tensor, and runs the
+effect **once** — a single launch over all channels at high occupancy. The native filter
+kernels treat every channel independently and are causal, so the trailing zero-pad never
+affects a signal's valid region; the result is numerically identical to processing each
+signal separately.
+
+Examples
+--------
+>>> import torch
+>>> import torchfx as fx
+>>> waves = [fx.Wave(torch.randn(1, 44100), 44100) for _ in range(64)]
+>>> out = fx.batch_process(waves, fx.filter.LoButterworth(4000, order=8))
+>>> len(out)
+64
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+from torch import nn
+
+from torchfx.wave import Wave
+
+__all__ = ["batch_process"]
+
+
+def batch_process(waves: Sequence[Wave], effect: nn.Module) -> list[Wave]:
+    """Apply ``effect`` to many :class:`~torchfx.Wave` signals in one batched launch.
+
+    Parameters
+    ----------
+    waves : Sequence[Wave]
+        Signals to process. All must share the same sampling rate and device. Lengths
+        and channel counts may differ.
+    effect : nn.Module
+        The effect or filter chain to apply (e.g. a filter, ``f1 | f2``, or any
+        :class:`~torchfx.FX`). It is applied to every signal with the shared ``fs``.
+
+    Returns
+    -------
+    list[Wave]
+        One output ``Wave`` per input, in the same order, each trimmed back to its
+        original length and channel count (and carrying its original metadata).
+
+    Raises
+    ------
+    ValueError
+        If ``waves`` is empty, or the signals do not share a single ``fs`` / device.
+
+    Notes
+    -----
+    Equivalent to ``[w | effect for w in waves]`` but issues a **single** native kernel
+    dispatch over the concatenated channels instead of one per signal, which fills the
+    GPU (and amortises Python dispatch + OpenMP setup on CPU) when many signals are
+    processed together — the CLI batch / watch workloads.
+
+    This holds only for effects that process each channel **independently** and causally
+    — filters, ``Gain``, the dynamics effects, per-channel ``Normalize``. Effects that
+    aggregate across channels or the whole signal (a global-peak ``Normalize``, mixing)
+    would see all the batched signals at once and are **not** batch-safe; apply those per
+    signal.
+
+    Examples
+    --------
+    >>> import torch
+    >>> import torchfx as fx
+    >>> waves = [fx.Wave(torch.randn(2, 24000), 48000) for _ in range(8)]
+    >>> out = fx.batch_process(waves, fx.effect.Gain(0.5))
+    >>> [w.ys.shape for w in out][0]
+    torch.Size([2, 24000])
+
+    """
+    if len(waves) == 0:
+        raise ValueError("batch_process requires at least one Wave.")
+
+    fs = waves[0].fs
+    device = waves[0].ys.device
+    dtype = waves[0].ys.dtype
+    for i, w in enumerate(waves):
+        if w.fs != fs:
+            raise ValueError(
+                f"All waves must share one sampling rate; wave[0].fs={fs} but "
+                f"wave[{i}].fs={w.fs}. Resample first or group by fs."
+            )
+        if w.ys.device != device:
+            raise ValueError(
+                f"All waves must be on the same device; wave[0] on {device} but "
+                f"wave[{i}] on {w.ys.device}."
+            )
+
+    lengths = [w.ys.shape[1] for w in waves]
+    channels = [w.ys.shape[0] for w in waves]
+    max_len = max(lengths)
+
+    # Pad each signal's tail with zeros to the common length, then stack on channels.
+    padded = [
+        (
+            w.ys
+            if w.ys.shape[1] == max_len
+            else torch.nn.functional.pad(w.ys, (0, max_len - w.ys.shape[1]))
+        )
+        for w in waves
+    ]
+    stacked = torch.cat(padded, dim=0).to(dtype=dtype)
+
+    # One pipeline evaluation over all channels => a single native dispatch.
+    processed = (Wave(stacked, fs, device=device) | effect).ys
+
+    results: list[Wave] = []
+    offset = 0
+    for c, length, w in zip(channels, lengths, waves, strict=True):
+        segment = processed[offset : offset + c, :length]
+        results.append(Wave(segment, fs, device=device, metadata=w.metadata))
+        offset += c
+    return results

--- a/src/torchfx/effect.py
+++ b/src/torchfx/effect.py
@@ -812,148 +812,118 @@ class PerChannelNormalizationStrategy(NormalizationStrategy):
 
 
 class Reverb(FX):
-    r"""Apply reverb effect using a feedback delay network for spatial ambiance.
+    r"""Freeverb-style algorithmic reverb (parallel combs + series all-passes).
 
-    The Reverb effect creates spatial ambiance by simulating sound reflections
-    in an acoustic space. It uses a simple feedback comb filter (feedback delay
-    network) to produce reverb-like effects with controllable decay time and
-    wet/dry mix.
-
-    This is a basic reverb implementation suitable for adding spatial depth to
-    audio signals. For more complex reverb algorithms, consider using convolution
-    reverbs with impulse responses.
+    Replaces the original single-comb reverb with the classic Schroeder/Moorer structure:
+    per channel, **8 parallel low-pass-feedback comb filters** are summed and fed through
+    **4 series all-pass diffusers**, producing a dense, natural decay. The comb/all-pass
+    delay tunings scale with the sampling rate so the character is consistent across
+    ``fs``. The network runs in a native per-channel C++/CUDA kernel.
 
     Parameters
     ----------
-    delay : int, optional
-        Delay time in samples for the feedback comb filter. Determines the
-        apparent size of the simulated space. Default is 4410 samples, which
-        corresponds to approximately 100ms at 44.1kHz sample rate.
-    decay : float, optional
-        Feedback decay factor controlling how quickly the reverb tail fades.
-        Must be in the range (0, 1). Higher values create longer reverb tails.
-        Default is 0.5.
-    mix : float, optional
-        Wet/dry mix controlling the balance between processed (wet) and
-        original (dry) signals. Range is [0, 1] where:
+    room_size : float, default=0.5
+        Apparent room size in ``[0, 1]`` — sets the comb feedback (decay length). Larger
+        values give a longer reverb tail.
+    damping : float, default=0.5
+        High-frequency damping in ``[0, 1]``. Larger values absorb highs faster, for a
+        warmer/darker tail.
+    mix : float, default=0.3
+        Wet/dry balance in ``[0, 1]`` (``0`` = dry, ``1`` = fully wet).
+    fs : int or None, default=None
+        Sampling rate in Hz, used to scale the delay tunings. May be left ``None`` and
+        supplied lazily by a ``Wave`` pipeline (``wave | reverb``).
 
-        - 0.0 = fully dry (no reverb)
-        - 1.0 = fully wet (only reverb)
-        - 0.5 = equal mix
-
-        Default is 0.5.
+    Returns
+    -------
+    Tensor
+        The reverberated waveform, same shape and dtype as the input.
 
     Raises
     ------
-    AssertionError
-        If delay is not positive, decay is not in (0, 1), or mix is not in [0, 1].
+    ValueError
+        If ``room_size``/``damping``/``mix`` are outside ``[0, 1]``, ``fs`` is
+        non-positive, or ``forward`` is called before ``fs`` is known.
 
     See Also
     --------
-    Delay : Multi-tap delay effect with BPM synchronization
-    Gain : Volume adjustment effect
+    Delay : Multi-tap delay effect with BPM synchronisation.
 
     Notes
     -----
-    **Algorithm:**
-
-    The reverb is computed using a feedback comb filter:
-
-    .. math::
-
-        y[n] = (1 - mix) \cdot x[n] + mix \cdot (x[n] + decay \cdot x[n - delay])
-
-    where:
-        - :math:`x[n]` is the input signal
-        - :math:`y[n]` is the output signal
-        - :math:`delay` is the delay time in samples
-        - :math:`decay` is the feedback decay factor
-        - :math:`mix` is the wet/dry mix parameter
-
-    **Processing Details:**
-
-    - If the input waveform is shorter than the delay time, the input is returned
-      unchanged.
-    - The effect processes tensors of arbitrary shape (..., time).
-    - Uses @torch.no_grad() decorator for efficient inference-only operation.
-    - Padding is applied using torch.nn.functional.pad for the delay buffer.
-
-    **Delay Time Calculation:**
-
-    To convert time in milliseconds to samples:
-
-    .. math::
-
-        delay_{samples} = \frac{time_{ms}}{1000} \cdot sample\_rate
-
-    For example, at 44.1kHz:
-        - 50ms = 2205 samples
-        - 100ms = 4410 samples (default)
-        - 200ms = 8820 samples
+    Each channel is processed independently with identical tunings (no stereo-width spread
+    — a possible follow-up). State is reset per ``forward`` call, so block-wise streaming
+    is not state-continuous across chunks. This is a **breaking change** from the pre-0.7
+    ``Reverb(delay, decay, mix)`` API.
 
     Examples
     --------
-    Basic reverb with default parameters:
+    >>> import torch
+    >>> from torchfx.effect import Reverb
+    >>> x = torch.randn(2, 48000)
+    >>> y = Reverb(room_size=0.7, damping=0.4, mix=0.3, fs=48000)(x)
+    >>> y.shape
+    torch.Size([2, 48000])
+
+    In a ``Wave`` pipeline (``fs`` supplied automatically):
 
     >>> import torchfx as fx
-    >>> wave = fx.Wave.from_file("audio.wav")
-    >>> reverb = fx.Reverb()
-    >>> processed = wave | reverb
-
-    Short room reverb (50ms delay):
-
-    >>> reverb = fx.Reverb(delay=2205, decay=0.4, mix=0.3)
-    >>> processed = wave | reverb
-
-    Long hall reverb (200ms delay):
-
-    >>> reverb = fx.Reverb(delay=8820, decay=0.7, mix=0.4)
-    >>> processed = wave | reverb
-
-    Subtle reverb with low mix:
-
-    >>> reverb = fx.Reverb(delay=4410, decay=0.5, mix=0.2)
-    >>> processed = wave | reverb
-
-    Direct tensor processing:
-
-    >>> import torch
-    >>> waveform = torch.randn(2, 44100)  # (channels, samples)
-    >>> reverb = fx.Reverb(delay=4410, decay=0.6, mix=0.3)
-    >>> reverberated = reverb(waveform)
-
-    Chain with other effects:
-
-    >>> processed = wave | fx.Gain(0.8) | fx.Reverb(delay=4410, decay=0.5, mix=0.3)
-
-    GPU processing:
-
-    >>> wave = wave.to("cuda")
-    >>> reverb = fx.Reverb(delay=4410, decay=0.6, mix=0.3).to("cuda")
-    >>> processed = wave | reverb
+    >>> processed = wave | fx.Reverb(room_size=0.8, mix=0.25)  # doctest: +SKIP
 
     """
 
-    def __init__(self, delay: int = 4410, decay: float = 0.5, mix: float = 0.5) -> None:
-        super().__init__()
-        assert delay > 0, "Delay must be positive."
-        assert 0 < decay < 1, "Decay must be between 0 and 1."
-        assert 0 <= mix <= 1, "Mix must be between 0 and 1."
+    # Freeverb fixed constants (input gain into the comb bank; all-pass feedback).
+    _INPUT_GAIN = 0.015
+    _ALLPASS_FB = 0.5
 
-        self.delay = delay
-        self.decay = decay
-        self.mix = mix
+    def __init__(
+        self,
+        room_size: float = 0.5,
+        damping: float = 0.5,
+        mix: float = 0.3,
+        fs: int | None = None,
+    ) -> None:
+        super().__init__()
+        if not 0 <= room_size <= 1:
+            raise ValueError(f"room_size must be in [0, 1], got {room_size}.")
+        if not 0 <= damping <= 1:
+            raise ValueError(f"damping must be in [0, 1], got {damping}.")
+        if not 0 <= mix <= 1:
+            raise ValueError(f"mix must be in [0, 1], got {mix}.")
+        if fs is not None and fs <= 0:
+            raise ValueError(f"Sample rate (fs) must be positive, got {fs}.")
+
+        self.room_size = float(room_size)
+        self.damping = float(damping)
+        self.mix = float(mix)
+        self.fs = fs
 
     @override
     @torch.no_grad()
     def forward(self, waveform: Tensor) -> Tensor:
-        # waveform: (..., time)
-        if waveform.size(-1) <= self.delay:
-            return waveform
+        if self.fs is None:
+            raise ValueError(
+                "Sample rate (fs) is required for the reverb. Use it in a Wave "
+                "pipeline (wave | reverb) or pass fs at construction."
+            )
+        if self.fs <= 0:
+            raise ValueError("Sample rate (fs) must be positive.")
 
-        from torchfx._ops import delay_line_forward
+        from torchfx._ops import reverb_forward
 
-        return delay_line_forward(waveform, self.delay, self.decay, self.mix)
+        # Freeverb parameter mapping: room_size -> comb feedback, damping -> LP coefficient.
+        feedback = self.room_size * 0.28 + 0.7
+        damp = self.damping * 0.4
+        return reverb_forward(
+            waveform,
+            self.fs,
+            feedback,
+            damp,
+            self._INPUT_GAIN,
+            self._ALLPASS_FB,
+            self.mix,  # wet
+            1.0 - self.mix,  # dry
+        )
 
 
 class DelayStrategy(abc.ABC):

--- a/src/torchfx/effect.py
+++ b/src/torchfx/effect.py
@@ -2003,3 +2003,143 @@ class Gate(Expander):
             detector=detector,
             fs=fs,
         )
+
+
+class Limiter(FX):
+    r"""Look-ahead brick-wall peak limiter.
+
+    Guarantees the output magnitude never exceeds ``threshold`` (a true brick wall) while
+    staying transparent: a short ``lookahead`` lets the gain reduce *before* a peak
+    arrives, so there is no transient overshoot and none of the distortion an
+    instantaneous gain change would cause. The gain then recovers over ``release``.
+
+    The look-ahead windowed peak of ``|x|`` is computed with a vectorised max-pool, and the
+    sequential gain recurrence runs in a native C++/CUDA kernel (one channel per thread).
+
+    Parameters
+    ----------
+    threshold : float, default=-1.0
+        Output ceiling in **dBFS**. The output magnitude never exceeds this.
+    lookahead : float, default=0.005
+        Look-ahead time in **seconds**: the gain is reduced over this window ahead of a
+        peak so the limiter never overshoots. ``0`` is a zero-look-ahead limiter.
+    release : float, default=0.05
+        Release time in **seconds** — how fast the gain recovers after a peak. ``0`` is
+        instantaneous.
+    fs : int or None, default=None
+        Sampling rate in Hz. May be left ``None`` and supplied lazily by a ``Wave``
+        pipeline (``wave | limiter``).
+
+    Returns
+    -------
+    Tensor
+        The limited waveform, same shape and dtype as the input, with
+        ``|y| <= 10**(threshold/20)`` everywhere.
+
+    Raises
+    ------
+    ValueError
+        If ``lookahead`` or ``release`` is negative, ``fs`` is non-positive, or ``forward``
+        is called before ``fs`` is known.
+
+    See Also
+    --------
+    Compressor : ``Compressor(ratio=inf)`` is a zero-look-ahead feed-forward limiter that
+        can overshoot on a single sample before its gain reacts; ``Limiter`` cannot.
+
+    Notes
+    -----
+    For each sample the applied gain is
+
+    .. math::
+
+        g[n] = \min\!\Big(\tfrac{T_\text{lin}}{\max(p[n], \epsilon)},\ a_R\,g[n-1] + (1-a_R)\Big),
+        \qquad p[n] = \max_{0 \le k \le L} |x[n+k]|
+
+    with linear ceiling :math:`T_\text{lin} = 10^{\text{threshold}/20}`, release coefficient
+    :math:`a_R = e^{-1/(\text{release}\cdot f_s)}`, and look-ahead :math:`L`. Since
+    :math:`|x[n]| \le p[n]`, the output :math:`y[n] = g[n]\,x[n]` satisfies
+    :math:`|y[n]| \le T_\text{lin}` — a guaranteed brick wall.
+
+    This is a **peak** (not true-peak / oversampled) limiter, so inter-sample peaks may
+    slightly exceed the ceiling after conversion to analog (true-peak limiting is a possible
+    follow-up). The output is time-aligned with the input (no net latency). Ballistics state
+    is reset per ``forward`` call (not state-continuous across streaming chunks).
+
+    Examples
+    --------
+    Brick-wall a signal that exceeds full scale to a -1 dBFS ceiling:
+
+    >>> import torch
+    >>> from torchfx.effect import Limiter
+    >>> x = torch.randn(2, 48000) * 3.0  # well over +/-1
+    >>> lim = Limiter(threshold=-1.0, lookahead=0.005, release=0.05, fs=48000)
+    >>> y = lim(x)
+    >>> bool(y.abs().max() <= 10 ** (-1.0 / 20) + 1e-4)
+    True
+
+    """
+
+    def __init__(
+        self,
+        threshold: float = -1.0,
+        lookahead: float = 0.005,
+        release: float = 0.05,
+        fs: int | None = None,
+    ) -> None:
+        super().__init__()
+        if lookahead < 0:
+            raise ValueError(f"lookahead must be non-negative (seconds), got {lookahead}.")
+        if release < 0:
+            raise ValueError(f"release must be non-negative (seconds), got {release}.")
+        if fs is not None and fs <= 0:
+            raise ValueError(f"Sample rate (fs) must be positive, got {fs}.")
+
+        self.threshold = float(threshold)
+        self.lookahead = float(lookahead)
+        self.release = float(release)
+        self.fs = fs
+
+        self._thr_lin = 10.0 ** (self.threshold / 20.0)
+        self._attack_coeff = 0.0
+        self._release_coeff = 0.0
+        self._lookahead_samples = 0
+        self._last_fs: int | None = None
+        self._needs_calculation = True
+
+    def _compute_coeffs(self) -> None:
+        """Derive ceiling, attack/release coefficients and look-ahead samples from
+        ``fs``."""
+        assert self.fs is not None
+        fs = self.fs
+        self._thr_lin = 10.0 ** (self.threshold / 20.0)
+        # Ramp the gain down over the look-ahead window so it is already low when the peak
+        # arrives (the per-sample clamp guarantees the brick wall regardless).
+        self._attack_coeff = 0.0 if self.lookahead == 0 else math.exp(-1.0 / (self.lookahead * fs))
+        self._release_coeff = 0.0 if self.release == 0 else math.exp(-1.0 / (self.release * fs))
+        self._lookahead_samples = int(round(self.lookahead * fs))
+        self._last_fs = fs
+        self._needs_calculation = False
+
+    @override
+    @torch.no_grad()
+    def forward(self, waveform: Tensor) -> Tensor:
+        if self._needs_calculation or self._last_fs != self.fs:
+            if self.fs is None:
+                raise ValueError(
+                    "Sample rate (fs) is required for the limiter. Use it in a "
+                    "Wave pipeline (wave | limiter) or pass fs at construction."
+                )
+            if self.fs <= 0:
+                raise ValueError("Sample rate (fs) must be positive.")
+            self._compute_coeffs()
+
+        from torchfx._ops import limiter_forward
+
+        return limiter_forward(
+            waveform,
+            self._thr_lin,
+            self._attack_coeff,
+            self._release_coeff,
+            self._lookahead_samples,
+        )

--- a/src/torchfx/effect.py
+++ b/src/torchfx/effect.py
@@ -1751,3 +1751,255 @@ class Compressor(FX):
             self._aRMS,
             1 if self.detector == "rms" else 0,
         )
+
+
+class Expander(FX):
+    r"""Downward expander / noise gate with a decoupled peak detector.
+
+    The mirror image of :class:`Compressor`: levels **below** ``threshold`` are turned
+    *down* (their dynamic range is expanded), which pushes quiet passages and noise
+    toward silence while leaving louder signal untouched. With a high ``ratio`` (or
+    ``ratio=inf``) it acts as a **noise gate**.
+
+    The side-chain level uses the same *decoupled* peak detector as the compressor (a
+    release max-hold followed by an attack one-pole; Giannoulis, Massberg & Reiss,
+    2012). Detection runs in native C++/CUDA, one channel per thread.
+
+    Parameters
+    ----------
+    threshold : float, default=-40.0
+        Level below which downward expansion begins, in **dBFS**.
+    ratio : float, default=2.0
+        Expansion ratio below the threshold (``>= 1.0``). ``2.0`` means a signal 1 dB
+        below threshold is pushed a further 1 dB down. ``float("inf")`` is a hard gate.
+    attack : float, default=0.005
+        Attack time in **seconds** (how fast the gate opens as level rises). ``0`` is
+        instantaneous.
+    release : float, default=0.05
+        Release time in **seconds** (how fast the gate closes as level falls). ``0`` is
+        instantaneous.
+    knee : float, default=6.0
+        Full width of the soft knee in **dB**, centred on the threshold. ``0`` gives a
+        hard knee.
+    floor : float or None, default=None
+        Deepest attenuation in **dB** (a negative number), limiting how far the signal
+        is pushed down — i.e. an expander/gate *range*. ``None`` applies no floor (full
+        downward expansion; with ``ratio=inf`` this gates to near-silence).
+    detector : {"peak", "rms"}, default="peak"
+        Side-chain level detection. ``"peak"`` follows ``|x|``; ``"rms"`` follows a
+        smoothed root-mean-square (averaging window tied to ``attack``).
+    fs : int or None, default=None
+        Sampling rate in Hz. May be left ``None`` and supplied lazily by a ``Wave``
+        pipeline (``wave | expander``).
+
+    Returns
+    -------
+    Tensor
+        The expanded waveform, same shape and dtype as the input.
+
+    Raises
+    ------
+    ValueError
+        If ``ratio < 1``, ``attack``/``release``/``knee`` is negative, ``floor`` is
+        positive, ``detector`` is not ``"peak"``/``"rms"``, ``fs`` is non-positive, or
+        ``forward`` is called before ``fs`` is known.
+
+    See Also
+    --------
+    Compressor : Reduces dynamic range *above* the threshold.
+    Gate : Convenience subclass with an infinite ratio (a hard noise gate).
+
+    Notes
+    -----
+    The detector is identical to :class:`Compressor`; only the static curve differs.
+    Per channel, with linear detector level :math:`L = 20\log_{10}(\max(y_L, \epsilon))`,
+    over-threshold amount :math:`o = L - T`, slope :math:`s = r - 1`, and soft knee of
+    width :math:`W`:
+
+    .. math::
+
+        g_{dB} =
+        \begin{cases}
+        -s\,(o - W/2)^2 / (2W) & |2o| \le W \quad (\text{knee}) \\
+        s\,o & o < 0 \quad (\text{below threshold}) \\
+        0 & \text{otherwise}
+        \end{cases}
+
+    clamped to ``floor`` (``g_{dB} \ge`` floor), and :math:`y[n] = 10^{g_{dB}/20}\,x[n]`.
+
+    This is a **zero-latency feed-forward** design (no look-ahead). The ballistics state
+    is reset on each ``forward`` call, so block-wise streaming is *not* state-continuous
+    across chunks (see the compressor streaming follow-up).
+
+    Examples
+    --------
+    Gently expand a signal 2:1 below -40 dBFS:
+
+    >>> import torch
+    >>> from torchfx.effect import Expander
+    >>> x = torch.randn(2, 48000) * 0.5  # (channels, samples)
+    >>> exp = Expander(threshold=-40.0, ratio=2.0, attack=0.005, release=0.1, fs=48000)
+    >>> y = exp(x)
+    >>> y.shape
+    torch.Size([2, 48000])
+
+    A noise gate (infinite ratio) with an 80 dB range:
+
+    >>> gate = Expander(threshold=-50.0, ratio=float("inf"), floor=-80.0, fs=48000)
+
+    References
+    ----------
+    D. Giannoulis, M. Massberg, J. D. Reiss, "Digital Dynamic Range Compressor
+    Design — A Tutorial and Analysis," J. Audio Eng. Soc., 60(6), 2012.
+
+    """
+
+    # Stands in for ``ratio=inf`` so the kernel never does inf arithmetic: a slope this
+    # steep drives any below-threshold sample straight to the floor (i.e. a hard gate).
+    _GATE_SLOPE = 1.0e6
+    # Applied when ``floor`` is None — far below any real signal, so effectively no floor.
+    _NO_FLOOR_DB = -240.0
+
+    def __init__(
+        self,
+        threshold: float = -40.0,
+        ratio: float = 2.0,
+        attack: float = 0.005,
+        release: float = 0.05,
+        knee: float = 6.0,
+        floor: float | None = None,
+        detector: str = "peak",
+        fs: int | None = None,
+    ) -> None:
+        super().__init__()
+        valid_detectors = {"peak", "rms"}
+        if detector not in valid_detectors:
+            raise ValueError(
+                f"detector must be one of {sorted(valid_detectors)}, got {detector!r}."
+            )
+        if ratio < 1.0:
+            raise ValueError(f"ratio must be >= 1.0, got {ratio}.")
+        if attack < 0:
+            raise ValueError(f"attack must be non-negative (seconds), got {attack}.")
+        if release < 0:
+            raise ValueError(f"release must be non-negative (seconds), got {release}.")
+        if knee < 0:
+            raise ValueError(f"knee must be non-negative (dB), got {knee}.")
+        if floor is not None and floor > 0:
+            raise ValueError(f"floor must be non-positive (dB of attenuation), got {floor}.")
+        if fs is not None and fs <= 0:
+            raise ValueError(f"Sample rate (fs) must be positive, got {fs}.")
+
+        self.threshold = float(threshold)
+        self.ratio = float(ratio)
+        self.attack = float(attack)
+        self.release = float(release)
+        self.knee = float(knee)
+        self.floor = None if floor is None else float(floor)
+        self.detector = detector
+        self.fs = fs
+
+        # slope = ratio - 1 (a large finite value for an infinite-ratio gate).
+        self._slope = self._GATE_SLOPE if math.isinf(self.ratio) else self.ratio - 1.0
+        self._floor_db = self._NO_FLOOR_DB if self.floor is None else self.floor
+        self._aA = 0.0
+        self._aR = 0.0
+        self._aRMS = 0.0
+        self._last_fs: int | None = None
+        self._needs_calculation = True
+
+    def _compute_coeffs(self) -> None:
+        """Derive attack/release/RMS coefficients from the times and ``fs``."""
+        assert self.fs is not None
+        fs = self.fs
+        self._aA = 0.0 if self.attack == 0 else math.exp(-1.0 / (self.attack * fs))
+        self._aR = 0.0 if self.release == 0 else math.exp(-1.0 / (self.release * fs))
+        # The RMS averaging window defaults to the attack time.
+        self._aRMS = 0.0 if self.attack == 0 else math.exp(-1.0 / (self.attack * fs))
+        self._last_fs = fs
+        self._needs_calculation = False
+
+    @override
+    @torch.no_grad()
+    def forward(self, waveform: Tensor) -> Tensor:
+        if self._needs_calculation or self._last_fs != self.fs:
+            if self.fs is None:
+                raise ValueError(
+                    "Sample rate (fs) is required for the expander. Use it in a "
+                    "Wave pipeline (wave | expander) or pass fs at construction."
+                )
+            if self.fs <= 0:
+                raise ValueError("Sample rate (fs) must be positive.")
+            self._compute_coeffs()
+
+        from torchfx._ops import expander_forward
+
+        return expander_forward(
+            waveform,
+            self.threshold,
+            self._slope,
+            self.knee,
+            self._floor_db,
+            self._aA,
+            self._aR,
+            self._aRMS,
+            1 if self.detector == "rms" else 0,
+        )
+
+
+class Gate(Expander):
+    r"""Noise gate — an :class:`Expander` with an infinite ratio (hard gating).
+
+    Below ``threshold`` the signal is attenuated to the ``floor`` (a hard downward
+    expansion); above it the signal passes unchanged. This is a basic gate without
+    hysteresis or a hold time (a possible future refinement).
+
+    Parameters
+    ----------
+    threshold : float, default=-50.0
+        Level below which the gate closes, in **dBFS**.
+    attack : float, default=0.001
+        How fast the gate opens as level rises, in **seconds**.
+    release : float, default=0.05
+        How fast the gate closes as level falls, in **seconds**.
+    floor : float or None, default=-80.0
+        Attenuation applied when the gate is closed, in **dB**. ``None`` gates to
+        near-silence.
+    knee : float, default=3.0
+        Soft-knee width in **dB** around the threshold.
+    detector : {"peak", "rms"}, default="peak"
+        Side-chain level detection.
+    fs : int or None, default=None
+        Sampling rate in Hz (may be supplied lazily by a ``Wave`` pipeline).
+
+    Examples
+    --------
+    >>> import torch
+    >>> from torchfx.effect import Gate
+    >>> x = torch.randn(1, 48000) * 0.5
+    >>> y = Gate(threshold=-45.0, floor=-90.0, fs=48000)(x)
+    >>> y.shape
+    torch.Size([1, 48000])
+
+    """
+
+    def __init__(
+        self,
+        threshold: float = -50.0,
+        attack: float = 0.001,
+        release: float = 0.05,
+        floor: float | None = -80.0,
+        knee: float = 3.0,
+        detector: str = "peak",
+        fs: int | None = None,
+    ) -> None:
+        super().__init__(
+            threshold=threshold,
+            ratio=float("inf"),
+            attack=attack,
+            release=release,
+            knee=knee,
+            floor=floor,
+            detector=detector,
+            fs=fs,
+        )

--- a/src/torchfx/effect.py
+++ b/src/torchfx/effect.py
@@ -1560,3 +1560,194 @@ class Delay(FX):
 
         # Wet/dry mix — fused via lerp (single kernel, avoids intermediates).
         return torch.lerp(waveform, delayed, self.mix)
+
+
+class Compressor(FX):
+    r"""Feed-forward dynamic-range compressor with a decoupled peak detector.
+
+    Reduces the dynamic range of a signal: levels above ``threshold`` are turned
+    down according to ``ratio``, with a soft ``knee`` around the threshold and
+    attack/release ballistics that control how quickly the gain reacts. An optional
+    ``makeup_gain`` restores overall loudness.
+
+    The side-chain level is tracked with a *decoupled* peak detector (a release
+    max-hold followed by an attack one-pole), the standard high-quality topology
+    (Giannoulis, Massberg & Reiss, 2012). Detection runs in native C++/CUDA, one
+    channel per thread.
+
+    Parameters
+    ----------
+    threshold : float, default=-20.0
+        Level above which compression begins, in **dBFS** (decibels relative to a
+        full-scale amplitude of 1.0).
+    ratio : float, default=4.0
+        Input/output ratio above the threshold (``>= 1.0``). ``4.0`` means 4 dB in
+        yields 1 dB out over threshold. ``float("inf")`` is a brick-wall limiter.
+    attack : float, default=0.005
+        Attack time in **seconds** (how fast gain reduction engages). ``0`` is
+        instantaneous.
+    release : float, default=0.05
+        Release time in **seconds** (how fast gain recovers). ``0`` is instantaneous.
+    knee : float, default=6.0
+        Full width of the soft knee in **dB**, centred on the threshold. ``0`` gives
+        a hard knee.
+    makeup_gain : float, default=0.0
+        Output gain applied after compression, in **dB**.
+    detector : {"peak", "rms"}, default="peak"
+        Side-chain level detection. ``"peak"`` follows ``|x|``; ``"rms"`` follows a
+        smoothed root-mean-square (averaging window tied to ``attack``).
+    fs : int or None, default=None
+        Sampling rate in Hz. May be left ``None`` and supplied lazily by a ``Wave``
+        pipeline (``wave | compressor``); the ballistics coefficients are then
+        derived from the times and ``fs`` on first ``forward``.
+
+    Returns
+    -------
+    Tensor
+        The compressed waveform, same shape and dtype as the input.
+
+    Raises
+    ------
+    ValueError
+        If ``ratio < 1``, ``attack``/``release``/``knee`` is negative, ``detector``
+        is not ``"peak"``/``"rms"``, ``fs`` is non-positive, or ``forward`` is called
+        before ``fs`` is known.
+
+    See Also
+    --------
+    Gain : Static volume adjustment.
+    Normalize : Amplitude normalization.
+
+    Notes
+    -----
+    Per channel, sequentially over samples :math:`n` (linear detector level, then
+    the gain computed in dB):
+
+    .. math::
+
+        \text{rect}[n] &= |x[n]| \quad (\text{peak}) \\
+        y_1[n] &= \max(\text{rect}[n],\ a_R\, y_1[n-1]) \\
+        y_L[n] &= a_A\, y_L[n-1] + (1 - a_A)\, y_1[n] \\
+        L &= 20 \log_{10}(\max(y_L[n], \epsilon))
+
+    with attack/release coefficients :math:`a_A = e^{-1/(\text{attack}\cdot f_s)}`,
+    :math:`a_R = e^{-1/(\text{release}\cdot f_s)}`. The static curve (soft knee of
+    width :math:`W` centred on threshold :math:`T`, ``r`` = ratio) maps :math:`L` to
+    :math:`L_{sc}`, and the per-sample gain is
+    :math:`g[n] = 10^{(L_{sc} - L + \text{makeup})/20}`, applied as
+    :math:`y[n] = g[n]\, x[n]`.
+
+    This is a **zero-latency feed-forward** design (no look-ahead). The ballistics
+    state is reset on each ``forward`` call, so block-wise streaming is *not*
+    state-continuous across chunks (a follow-up could thread the state in/out).
+
+    Examples
+    --------
+    Compress a signal 4:1 above -12 dBFS:
+
+    >>> import torch
+    >>> from torchfx.effect import Compressor
+    >>> x = torch.randn(2, 48000) * 0.5  # (channels, samples)
+    >>> comp = Compressor(threshold=-12.0, ratio=4.0, attack=0.005, release=0.08, fs=48000)
+    >>> y = comp(x)
+    >>> y.shape
+    torch.Size([2, 48000])
+
+    Use in a ``Wave`` pipeline (``fs`` is supplied automatically):
+
+    >>> import torchfx as fx
+    >>> processed = wave | fx.effect.Compressor(threshold=-18.0, ratio=3.0)  # doctest: +SKIP
+
+    Brick-wall limiting at -1 dBFS with makeup gain:
+
+    >>> limiter = Compressor(threshold=-1.0, ratio=float("inf"), makeup_gain=1.0, fs=48000)
+
+    References
+    ----------
+    D. Giannoulis, M. Massberg, J. D. Reiss, "Digital Dynamic Range Compressor
+    Design — A Tutorial and Analysis," J. Audio Eng. Soc., 60(6), 2012.
+
+    """
+
+    def __init__(
+        self,
+        threshold: float = -20.0,
+        ratio: float = 4.0,
+        attack: float = 0.005,
+        release: float = 0.05,
+        knee: float = 6.0,
+        makeup_gain: float = 0.0,
+        detector: str = "peak",
+        fs: int | None = None,
+    ) -> None:
+        super().__init__()
+        valid_detectors = {"peak", "rms"}
+        if detector not in valid_detectors:
+            raise ValueError(
+                f"detector must be one of {sorted(valid_detectors)}, got {detector!r}."
+            )
+        if ratio < 1.0:
+            raise ValueError(f"ratio must be >= 1.0, got {ratio}.")
+        if attack < 0:
+            raise ValueError(f"attack must be non-negative (seconds), got {attack}.")
+        if release < 0:
+            raise ValueError(f"release must be non-negative (seconds), got {release}.")
+        if knee < 0:
+            raise ValueError(f"knee must be non-negative (dB), got {knee}.")
+        if fs is not None and fs <= 0:
+            raise ValueError(f"Sample rate (fs) must be positive, got {fs}.")
+
+        self.threshold = float(threshold)
+        self.ratio = float(ratio)
+        self.attack = float(attack)
+        self.release = float(release)
+        self.knee = float(knee)
+        self.makeup_gain = float(makeup_gain)
+        self.detector = detector
+        self.fs = fs
+
+        # 1/ratio (0 for an inf-ratio limiter) so the kernel never does inf math.
+        self._inv_ratio = 0.0 if math.isinf(self.ratio) else 1.0 / self.ratio
+        self._aA = 0.0
+        self._aR = 0.0
+        self._aRMS = 0.0
+        self._last_fs: int | None = None
+        self._needs_calculation = True
+
+    def _compute_coeffs(self) -> None:
+        """Derive attack/release/RMS coefficients from the times and ``fs``."""
+        assert self.fs is not None
+        fs = self.fs
+        self._aA = 0.0 if self.attack == 0 else math.exp(-1.0 / (self.attack * fs))
+        self._aR = 0.0 if self.release == 0 else math.exp(-1.0 / (self.release * fs))
+        # The RMS averaging window defaults to the attack time.
+        self._aRMS = 0.0 if self.attack == 0 else math.exp(-1.0 / (self.attack * fs))
+        self._last_fs = fs
+        self._needs_calculation = False
+
+    @override
+    @torch.no_grad()
+    def forward(self, waveform: Tensor) -> Tensor:
+        if self._needs_calculation or self._last_fs != self.fs:
+            if self.fs is None:
+                raise ValueError(
+                    "Sample rate (fs) is required for the compressor. Use it in a "
+                    "Wave pipeline (wave | compressor) or pass fs at construction."
+                )
+            if self.fs <= 0:
+                raise ValueError("Sample rate (fs) must be positive.")
+            self._compute_coeffs()
+
+        from torchfx._ops import compressor_forward
+
+        return compressor_forward(
+            waveform,
+            self.threshold,
+            self._inv_ratio,
+            self.knee,
+            self.makeup_gain,
+            self._aA,
+            self._aR,
+            self._aRMS,
+            1 if self.detector == "rms" else 0,
+        )

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,0 +1,135 @@
+"""Tests for batched multi-signal processing (issue #19)."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+import torch
+
+import torchfx as fx
+from torchfx import Wave, _ops, batch_process
+from torchfx.effect import Gain
+from torchfx.filter.iir import HiButterworth, LoButterworth
+
+FS = 48000
+
+
+@contextmanager
+def count_sos():
+    """Count native SOS dispatches (to assert the batch is a single launch)."""
+    n = {"sos": 0}
+    orig = _ops.parallel_iir_forward
+
+    def wrap(*a: Any, **k: Any) -> Any:
+        n["sos"] += 1
+        return orig(*a, **k)
+
+    _ops.parallel_iir_forward = wrap
+    try:
+        yield n
+    finally:
+        _ops.parallel_iir_forward = orig
+
+
+def _wave(c: int, t: int, seed: int) -> Wave:
+    gen = torch.Generator().manual_seed(seed)
+    return Wave(torch.randn(c, t, generator=gen, dtype=torch.float64), FS)
+
+
+# --------------------------------------------------------------------------- #
+# Numerical equivalence to per-file processing
+# --------------------------------------------------------------------------- #
+def test_batch_equals_per_file_filter():
+    specs = [(1, 4000), (2, 6000), (1, 5000), (2, 3000)]
+    waves = [_wave(c, t, i) for i, (c, t) in enumerate(specs)]
+    out = batch_process(waves, LoButterworth(4000, order=8))
+    assert len(out) == len(waves)
+    for w, o in zip(waves, out, strict=True):
+        ref = (w | LoButterworth(4000, order=8)).ys
+        assert o.ys.shape == w.ys.shape
+        torch.testing.assert_close(o.ys, ref, rtol=1e-9, atol=1e-12)
+
+
+def test_batch_equals_per_file_chain():
+    waves = [_wave(2, 4000 + 500 * i, i) for i in range(5)]
+    out = batch_process(waves, HiButterworth(120, order=4) | LoButterworth(8000, order=4))
+    for w, o in zip(waves, out, strict=True):
+        ref = (w | (HiButterworth(120, order=4) | LoButterworth(8000, order=4))).ys
+        torch.testing.assert_close(o.ys, ref, rtol=1e-9, atol=1e-12)
+
+
+def test_batch_equals_per_file_gain():
+    waves = [_wave(1, 2000, i) for i in range(4)]
+    out = batch_process(waves, Gain(0.5))
+    for w, o in zip(waves, out, strict=True):
+        torch.testing.assert_close(o.ys, w.ys * 0.5, rtol=1e-9, atol=1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# Single dispatch (the whole point: one launch for the batch)
+# --------------------------------------------------------------------------- #
+def test_batch_is_single_dispatch():
+    waves = [_wave(2, 4000, i) for i in range(16)]
+    with count_sos() as n:
+        batch_process(waves, LoButterworth(4000, order=8))
+    assert n["sos"] == 1, f"batch of 16 should be one SOS dispatch, got {n['sos']}"
+
+
+def test_per_file_is_n_dispatches():
+    waves = [_wave(2, 4000, i) for i in range(16)]
+    with count_sos() as n:
+        for w in waves:
+            _ = (w | LoButterworth(4000, order=8)).ys
+    assert n["sos"] == 16
+
+
+# --------------------------------------------------------------------------- #
+# Shapes, metadata, validation
+# --------------------------------------------------------------------------- #
+def test_preserves_shapes_and_metadata():
+    w0 = Wave(torch.randn(2, 7000, dtype=torch.float64), FS, metadata={"src": "a"})
+    w1 = Wave(torch.randn(1, 3000, dtype=torch.float64), FS, metadata={"src": "b"})
+    out = batch_process([w0, w1], Gain(1.0))
+    assert out[0].ys.shape == (2, 7000)
+    assert out[1].ys.shape == (1, 3000)
+    assert out[0].metadata == {"src": "a"}
+    assert out[1].metadata == {"src": "b"}
+
+
+def test_single_wave_batch():
+    w = _wave(2, 5000, 0)
+    out = batch_process([w], LoButterworth(4000, order=6))
+    torch.testing.assert_close(out[0].ys, (w | LoButterworth(4000, order=6)).ys)
+
+
+def test_empty_raises():
+    with pytest.raises(ValueError, match="at least one"):
+        batch_process([], Gain(1.0))
+
+
+def test_mixed_fs_raises():
+    w0 = Wave(torch.randn(1, 1000, dtype=torch.float64), 48000)
+    w1 = Wave(torch.randn(1, 1000, dtype=torch.float64), 44100)
+    with pytest.raises(ValueError, match="sampling rate"):
+        batch_process([w0, w1], Gain(1.0))
+
+
+def test_exported_at_top_level():
+    assert fx.batch_process is batch_process
+
+
+# --------------------------------------------------------------------------- #
+# GPU: batch == per-file == CPU, in one launch
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_batch_gpu_matches_cpu():
+    specs = [(1, 4000), (2, 6000), (2, 5000)]
+    waves_cpu = [_wave(c, t, i) for i, (c, t) in enumerate(specs)]
+    waves_gpu = [Wave(w.ys.cuda(), FS) for w in waves_cpu]
+    out_cpu = batch_process(waves_cpu, LoButterworth(4000, order=8))
+    out_gpu = batch_process(waves_gpu, LoButterworth(4000, order=8))
+    for oc, og in zip(out_cpu, out_gpu, strict=True):
+        assert og.ys.is_cuda
+        torch.testing.assert_close(oc.ys, og.ys.cpu(), rtol=1e-9, atol=1e-10)

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -127,7 +127,7 @@ def test_exported_at_top_level():
 def test_batch_gpu_matches_cpu():
     specs = [(1, 4000), (2, 6000), (2, 5000)]
     waves_cpu = [_wave(c, t, i) for i, (c, t) in enumerate(specs)]
-    waves_gpu = [Wave(w.ys.cuda(), FS) for w in waves_cpu]
+    waves_gpu = [Wave(w.ys, FS, device="cuda") for w in waves_cpu]
     out_cpu = batch_process(waves_cpu, LoButterworth(4000, order=8))
     out_gpu = batch_process(waves_gpu, LoButterworth(4000, order=8))
     for oc, og in zip(out_cpu, out_gpu, strict=True):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,11 +99,11 @@ class TestParseEffectString:
         assert fx.gain == pytest.approx(0.5)
 
     def test_keyword_params(self) -> None:
-        fx = parse_effect_string("reverb:decay=0.6,mix=0.3")
+        fx = parse_effect_string("reverb:room_size=0.6,mix=0.3")
         from torchfx.effect import Reverb
 
         assert isinstance(fx, Reverb)
-        assert fx.decay == pytest.approx(0.6)
+        assert fx.room_size == pytest.approx(0.6)
         assert fx.mix == pytest.approx(0.3)
 
     def test_mixed_positional_and_keyword(self) -> None:

--- a/tests/test_compressor.py
+++ b/tests/test_compressor.py
@@ -1,0 +1,218 @@
+"""Tests for the Compressor dynamics effect (issue #30)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from torchfx.effect import Compressor
+
+FS = 48000
+
+
+def _static_gain_db(level_db: float, threshold: float, ratio: float, knee: float) -> float:
+    """Reference static gain-reduction curve (matches the kernel, in dB)."""
+    inv_ratio = 0.0 if math.isinf(ratio) else 1.0 / ratio
+    over = level_db - threshold
+    if knee > 0 and 2 * abs(over) <= knee:
+        t = over + knee / 2
+        lsc = level_db + (inv_ratio - 1) * t * t / (2 * knee)
+    elif over > 0:
+        lsc = threshold + over * inv_ratio
+    else:
+        lsc = level_db
+    return lsc - level_db
+
+
+def _const(amp: float, n: int = 2048, c: int = 1, dtype=torch.float64) -> torch.Tensor:
+    return torch.full((c, n), amp, dtype=dtype)
+
+
+# --------------------------------------------------------------------------- #
+# Static gain curve (attack=release=0 -> instantaneous detector = |x|)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("level_db", [-30.0, -20.0, -12.0, -6.0, 0.0])
+@pytest.mark.parametrize("ratio", [2.0, 4.0, 10.0])
+@pytest.mark.parametrize("knee", [0.0, 6.0])
+def test_static_curve_matches_reference(level_db, ratio, knee):
+    threshold = -18.0
+    amp = 10 ** (level_db / 20)
+    comp = Compressor(threshold=threshold, ratio=ratio, attack=0.0, release=0.0, knee=knee, fs=FS)
+    y = comp(_const(amp))
+    g_db = _static_gain_db(level_db, threshold, ratio, knee)
+    expected = amp * 10 ** (g_db / 20)
+    torch.testing.assert_close(y, torch.full_like(y, expected), rtol=1e-5, atol=1e-7)
+
+
+def test_below_threshold_is_unity():
+    comp = Compressor(threshold=-12.0, ratio=4.0, attack=0.0, release=0.0, knee=0.0, fs=FS)
+    x = _const(10 ** (-24.0 / 20))  # well below threshold
+    torch.testing.assert_close(comp(x), x, rtol=1e-6, atol=1e-9)
+
+
+def test_limiter_clamps_at_threshold():
+    threshold = -10.0
+    comp = Compressor(
+        threshold=threshold, ratio=float("inf"), attack=0.0, release=0.0, knee=0.0, fs=FS
+    )
+    for level_db in (-5.0, 0.0, 6.0):
+        amp = 10 ** (level_db / 20)
+        y = comp(_const(amp))
+        out_db = 20 * math.log10(float(y.abs().max()))
+        assert out_db == pytest.approx(threshold, abs=1e-4)
+
+
+def test_makeup_gain_on_uncompressed():
+    comp = Compressor(
+        threshold=-6.0, ratio=4.0, attack=0.0, release=0.0, knee=0.0, makeup_gain=6.0, fs=FS
+    )
+    x = _const(10 ** (-30.0 / 20))  # below threshold -> only makeup applies
+    torch.testing.assert_close(comp(x), x * 10 ** (6.0 / 20), rtol=1e-5, atol=1e-8)
+
+
+def test_soft_knee_continuous():
+    # Sweep input level across the knee; the gain-reduction curve must be continuous.
+    threshold, ratio, knee = -18.0, 4.0, 8.0
+    comp = Compressor(threshold=threshold, ratio=ratio, attack=0.0, release=0.0, knee=knee, fs=FS)
+    prev = None
+    for level_db in [threshold + d for d in torch.linspace(-6, 6, 25).tolist()]:
+        amp = 10 ** (level_db / 20)
+        out_db = 20 * math.log10(float(comp(_const(amp)).abs().max()))
+        gr = out_db - level_db
+        if prev is not None:
+            assert abs(gr - prev) < 0.6  # no discontinuity across the knee
+        prev = gr
+
+
+# --------------------------------------------------------------------------- #
+# Ballistics
+# --------------------------------------------------------------------------- #
+def test_attack_smoothing_ramps_in():
+    # Loud step: gain reduction engages over ~attack, so the onset sample is louder
+    # (less reduction) than the settled region.
+    comp = Compressor(threshold=-20.0, ratio=8.0, attack=0.02, release=0.05, knee=0.0, fs=FS)
+    x = _const(10 ** (-3.0 / 20), n=4096)
+    y = comp(x).abs()
+    assert float(y[0, 0]) > float(y[0, -1]) + 1e-4  # onset less compressed than settled
+
+
+def test_release_recovers_after_loud():
+    # loud (compressed) -> silence: the held gain reduction recovers over ~release.
+    comp = Compressor(threshold=-20.0, ratio=8.0, attack=0.001, release=0.05, knee=0.0, fs=FS)
+    loud = 10 ** (-3.0 / 20)
+    # Tail long enough for the held level (-3 dBFS) to decay below threshold (-20 dB).
+    x = torch.cat([_const(loud, n=2000), _const(1e-4, n=16000)], dim=1)
+    y = comp(x)
+    quiet = y[:, 2000:]
+    # gain (out/in) over the quiet tail rises back toward unity as the hold releases.
+    gain = (quiet.abs() / 1e-4)[0]
+    assert float(gain[-1]) > float(gain[0])  # recovers
+    assert float(gain[0]) < 0.5  # starts compressed (~8:1 at -3 dBFS over -20 dB)
+    assert float(gain[-1]) == pytest.approx(1.0, abs=1e-2)  # fully recovered
+
+
+def test_coefficient_formula():
+    comp = Compressor(attack=0.01, release=0.1, fs=FS)
+    comp(_const(0.1))  # triggers coeff computation
+    assert comp._aA == pytest.approx(math.exp(-1.0 / (0.01 * FS)))
+    assert comp._aR == pytest.approx(math.exp(-1.0 / (0.1 * FS)))
+
+
+# --------------------------------------------------------------------------- #
+# Detector modes
+# --------------------------------------------------------------------------- #
+def test_rms_less_reduction_than_peak_on_sine():
+    t = torch.arange(FS, dtype=torch.float64) / FS
+    x = (0.7 * torch.sin(2 * math.pi * 1000 * t)).unsqueeze(0)
+    peak = Compressor(threshold=-20.0, ratio=4.0, detector="peak", fs=FS)(x)
+    rms = Compressor(threshold=-20.0, ratio=4.0, detector="rms", fs=FS)(x)
+    # RMS of a sine is ~3 dB below its peak, so it compresses less (louder output).
+    assert float(rms.abs().mean()) > float(peak.abs().mean())
+
+
+# --------------------------------------------------------------------------- #
+# Shapes / dtypes / device
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("shape", [(2048,), (2, 2048), (3, 2, 2048)])
+def test_shape_preserved(shape):
+    comp = Compressor(threshold=-12.0, ratio=4.0, fs=FS)
+    x = torch.randn(*shape) * 0.5
+    assert comp(x).shape == x.shape
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_dtype_preserved(dtype):
+    comp = Compressor(threshold=-12.0, ratio=4.0, fs=FS)
+    x = (torch.randn(2, 1024) * 0.5).to(dtype)
+    assert comp(x).dtype == dtype
+
+
+def test_identical_channels_identical_output():
+    comp = Compressor(threshold=-15.0, ratio=4.0, attack=0.003, release=0.05, fs=FS)
+    ch = torch.randn(1, 4096) * 0.6
+    y = comp(torch.cat([ch, ch], dim=0))
+    torch.testing.assert_close(y[0], y[1])
+
+
+def test_silent_input_silent_output():
+    comp = Compressor(threshold=-20.0, ratio=4.0, fs=FS)
+    x = torch.zeros(2, 1024)
+    assert torch.all(comp(x) == 0)
+
+
+# --------------------------------------------------------------------------- #
+# fs propagation
+# --------------------------------------------------------------------------- #
+def test_fs_required_without_pipeline():
+    comp = Compressor(threshold=-12.0, ratio=4.0)  # no fs
+    with pytest.raises(ValueError, match=r"Sample rate \(fs\) is required"):
+        comp(torch.randn(1, 256))
+
+
+def test_fs_set_via_attribute_recomputes():
+    comp = Compressor(attack=0.01, fs=44100)
+    comp(_const(0.1))
+    a1 = comp._aA
+    comp.fs = 48000  # mimics Wave.__update_config
+    comp(_const(0.1))
+    assert comp._aA != a1
+    assert comp._aA == pytest.approx(math.exp(-1.0 / (0.01 * 48000)))
+
+
+# --------------------------------------------------------------------------- #
+# Validation
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"ratio": 0.5},
+        {"attack": -0.1},
+        {"release": -0.1},
+        {"knee": -1.0},
+        {"detector": "median"},
+        {"fs": 0},
+        {"fs": -48000},
+    ],
+)
+def test_invalid_params_raise(kwargs):
+    with pytest.raises(ValueError):
+        Compressor(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# CPU / CUDA parity
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("detector", ["peak", "rms"])
+@pytest.mark.parametrize("ratio", [4.0, float("inf")])
+def test_cpu_cuda_parity(detector, ratio):
+    g = torch.Generator().manual_seed(0)
+    x = torch.randn(3, 4096, generator=g, dtype=torch.float32) * 0.6
+    comp = Compressor(
+        threshold=-18.0, ratio=ratio, attack=0.004, release=0.06, detector=detector, fs=FS
+    )
+    y_cpu = comp(x)
+    y_cuda = comp(x.cuda()).cpu()
+    torch.testing.assert_close(y_cuda, y_cpu, rtol=1e-4, atol=1e-4)

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -15,7 +15,6 @@ from torchfx.effect import (
     PercentileNormalizationStrategy,
     PerChannelNormalizationStrategy,
     PingPongDelayStrategy,
-    Reverb,
     RMSNormalizationStrategy,
 )
 
@@ -200,93 +199,7 @@ def test_per_channel_normalization_strategy_zero():
     torch.testing.assert_close(out, waveform)
 
 
-def test_reverb_basic():
-    # Simple waveform, delay=2, decay=0.5, mix=1.0 (fully wet)
-    waveform = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0])
-    reverb = Reverb(delay=2, decay=0.5, mix=1.0)
-    # Expected: y[n] = x[n] + 0.5 * x[n-2] for n >= 2, else x[n]
-    expected = torch.tensor(
-        [
-            1.0,  # n=0: no delay
-            2.0,  # n=1: no delay
-            3.0 + 0.5 * 1.0,  # n=2
-            4.0 + 0.5 * 2.0,  # n=3
-            5.0 + 0.5 * 3.0,  # n=4
-        ]
-    )
-    out = reverb(waveform)
-    torch.testing.assert_close(out, expected)
-
-
-def test_reverb_mix_zero():
-    # mix=0 should return the original waveform
-    waveform = torch.randn(10)
-    reverb = Reverb(delay=3, decay=0.7, mix=0.0)
-    out = reverb(waveform)
-    torch.testing.assert_close(out, waveform)
-
-
-def test_reverb_short_waveform():
-    # If waveform shorter than delay, should return unchanged
-    waveform = torch.tensor([1.0, 2.0])
-    reverb = Reverb(delay=3, decay=0.5, mix=1.0)
-    out = reverb(waveform)
-    torch.testing.assert_close(out, waveform)
-
-
-def test_reverb_multichannel():
-    # Test with 2D waveform (channels, time)
-    waveform = torch.tensor([[1.0, 2.0, 3.0, 4.0], [0.5, 1.5, 2.5, 3.5]])
-    reverb = Reverb(delay=2, decay=0.5, mix=1.0)
-    expected = torch.empty_like(waveform)
-    # Channel 0
-    expected[0, 0] = 1.0
-    expected[0, 1] = 2.0
-    expected[0, 2] = 3.0 + 0.5 * 1.0
-    expected[0, 3] = 4.0 + 0.5 * 2.0
-    # Channel 1
-    expected[1, 0] = 0.5
-    expected[1, 1] = 1.5
-    expected[1, 2] = 2.5 + 0.5 * 0.5
-    expected[1, 3] = 3.5 + 0.5 * 1.5
-    out = reverb(waveform)
-    torch.testing.assert_close(out, expected)
-
-
-def test_reverb_batched_3d_input():
-    waveform = torch.randn(2, 3, 128)
-    reverb = Reverb(delay=4, decay=0.4, mix=0.5)
-    out = reverb(waveform)
-
-    assert out.shape == waveform.shape
-    assert torch.isfinite(out).all()
-
-
-def test_reverb_float16_input_supported():
-    waveform = torch.randn(1, 64, dtype=torch.float16)
-    reverb = Reverb(delay=3, decay=0.2, mix=0.5)
-    out = reverb(waveform)
-
-    assert out.dtype == torch.float16
-    assert out.shape == waveform.shape
-
-
-@pytest.mark.parametrize("delay", [0, -1])
-def test_reverb_invalid_delay(delay):
-    with pytest.raises(AssertionError):
-        Reverb(delay=delay, decay=0.5, mix=0.5)
-
-
-@pytest.mark.parametrize("decay", [0.0, 1.0, -0.1, 1.1])
-def test_reverb_invalid_decay(decay):
-    with pytest.raises(AssertionError):
-        Reverb(delay=2, decay=decay, mix=0.5)
-
-
-@pytest.mark.parametrize("mix", [-0.1, 1.1])
-def test_reverb_invalid_mix(mix):
-    with pytest.raises(AssertionError):
-        Reverb(delay=2, decay=0.5, mix=mix)
+# Reverb tests live in tests/test_reverb.py (Freeverb-style, issue #18).
 
 
 # Delay tests

--- a/tests/test_expander.py
+++ b/tests/test_expander.py
@@ -1,0 +1,232 @@
+"""Tests for the Expander / Gate dynamics effect (issue #32)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from torchfx.effect import Expander, Gate
+
+FS = 48000
+_NO_FLOOR = -240.0
+
+
+def _static_gain_db(
+    level_db: float, threshold: float, ratio: float, knee: float, floor: float = _NO_FLOOR
+) -> float:
+    """Reference downward-expander static gain curve (matches the kernel, in dB)."""
+    slope = 1.0e6 if math.isinf(ratio) else ratio - 1.0
+    over = level_db - threshold
+    if knee > 0 and 2 * abs(over) <= knee:
+        t = over - knee / 2
+        gdb = -slope * t * t / (2 * knee)
+    elif over < 0:
+        gdb = slope * over
+    else:
+        gdb = 0.0
+    return max(gdb, floor)
+
+
+def _const(amp: float, n: int = 2048, c: int = 1, dtype=torch.float64) -> torch.Tensor:
+    return torch.full((c, n), amp, dtype=dtype)
+
+
+# --------------------------------------------------------------------------- #
+# Static gain curve (attack=release=0 -> instantaneous detector = |x|)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("level_db", [-50.0, -42.0, -36.0, -30.0, -24.0])
+@pytest.mark.parametrize("ratio", [2.0, 4.0, 10.0])
+@pytest.mark.parametrize("knee", [0.0, 6.0])
+def test_static_curve_matches_reference(level_db, ratio, knee):
+    threshold = -30.0
+    amp = 10 ** (level_db / 20)
+    exp = Expander(threshold=threshold, ratio=ratio, attack=0.0, release=0.0, knee=knee, fs=FS)
+    y = exp(_const(amp))
+    g_db = _static_gain_db(level_db, threshold, ratio, knee)
+    expected = amp * 10 ** (g_db / 20)
+    torch.testing.assert_close(y, torch.full_like(y, expected), rtol=1e-5, atol=1e-9)
+
+
+def test_above_threshold_is_unity():
+    exp = Expander(threshold=-40.0, ratio=4.0, attack=0.0, release=0.0, knee=0.0, fs=FS)
+    x = _const(10 ** (-12.0 / 20))  # well above threshold
+    torch.testing.assert_close(exp(x), x, rtol=1e-6, atol=1e-9)
+
+
+def test_below_threshold_is_attenuated():
+    exp = Expander(threshold=-30.0, ratio=4.0, attack=0.0, release=0.0, knee=0.0, fs=FS)
+    amp = 10 ** (-42.0 / 20)  # 12 dB below threshold
+    y = exp(_const(amp))
+    # ratio 4 -> a further (4-1)*12 = 36 dB down: output = amp * 10^(-36/20)
+    expected = amp * 10 ** (-36.0 / 20)
+    torch.testing.assert_close(y, torch.full_like(y, expected), rtol=1e-5, atol=1e-12)
+    assert y.abs().max().item() < amp  # genuinely quieter
+
+
+def test_infinite_ratio_gates_to_floor():
+    floor = -80.0
+    exp = Expander(
+        threshold=-30.0, ratio=float("inf"), attack=0.0, release=0.0, knee=0.0, floor=floor, fs=FS
+    )
+    amp = 10 ** (-36.0 / 20)  # below threshold
+    y = exp(_const(amp))
+    expected = amp * 10 ** (floor / 20)
+    torch.testing.assert_close(y, torch.full_like(y, expected), rtol=1e-5, atol=1e-12)
+
+
+def test_floor_clamps_attenuation():
+    floor = -20.0
+    exp = Expander(
+        threshold=-20.0, ratio=10.0, attack=0.0, release=0.0, knee=0.0, floor=floor, fs=FS
+    )
+    amp = 10 ** (-60.0 / 20)  # 40 dB below -> would be (10-1)*40 = 360 dB down, clamped
+    y = exp(_const(amp))
+    expected = amp * 10 ** (floor / 20)
+    torch.testing.assert_close(y, torch.full_like(y, expected), rtol=1e-5, atol=1e-12)
+
+
+def test_soft_knee_is_continuous():
+    threshold, knee = -30.0, 8.0
+    exp = Expander(threshold=threshold, ratio=6.0, attack=0.0, release=0.0, knee=knee, fs=FS)
+    levels = torch.linspace(threshold - knee, threshold + knee, 40)
+    gains = []
+    for lvl in levels.tolist():
+        amp = 10 ** (lvl / 20)
+        gains.append((exp(_const(amp)).mean() / amp).item())
+    gains_t = torch.tensor(gains)
+    # No jumps across the knee (gain is monotonic non-decreasing and smooth in level).
+    assert torch.all(gains_t.diff() >= -1e-6)
+    assert gains_t.diff().abs().max() < 0.1
+
+
+# --------------------------------------------------------------------------- #
+# Ballistics
+# --------------------------------------------------------------------------- #
+def test_release_closes_after_signal_drops():
+    """A loud burst then silence: the gate closes (gain falls) over the release."""
+    exp = Expander(
+        threshold=-30.0, ratio=float("inf"), attack=0.0, release=0.05, floor=-90.0, fs=FS
+    )
+    loud = torch.full((1, 2000), 0.5, dtype=torch.float64)
+    quiet = torch.full((1, 16000), 10 ** (-50.0 / 20), dtype=torch.float64)  # below threshold
+    x = torch.cat([loud, quiet], dim=1)
+    y = exp(x)
+    g = y[0, 2000:].abs() / x[0, 2000:].abs()
+    assert g[0].item() > 0.5  # still open right after the burst (release not elapsed)
+    assert g[-1].item() < 1e-3  # fully closed by the end
+
+
+def test_attack_opens_gradually():
+    """Silence then a tone: with a slow attack the gate opens over time, not instantly."""
+    exp = Expander(
+        threshold=-30.0, ratio=float("inf"), attack=0.02, release=0.2, floor=-90.0, fs=FS
+    )
+    quiet = torch.full((1, 4000), 10 ** (-50.0 / 20), dtype=torch.float64)
+    loud = torch.full((1, 8000), 0.5, dtype=torch.float64)
+    x = torch.cat([quiet, loud], dim=1)
+    y = exp(x)
+    g = y[0, 4000:].abs() / x[0, 4000:].abs()
+    assert g[0].item() < g[2000].item()  # opening up
+    assert g[-1].item() > 0.9  # fully open at the end
+
+
+def test_peak_vs_rms_differ():
+    g_peak = Expander(threshold=-20.0, ratio=4.0, detector="peak", fs=FS)
+    g_rms = Expander(threshold=-20.0, ratio=4.0, detector="rms", fs=FS)
+    gen = torch.Generator().manual_seed(0)
+    x = torch.randn(1, 8000, generator=gen, dtype=torch.float64) * 0.02
+    assert not torch.allclose(g_peak(x), g_rms(x))
+
+
+# --------------------------------------------------------------------------- #
+# Shapes, dtypes, channels
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("shape", [(4096,), (2, 4096), (3, 2, 4096)])
+def test_shapes_preserved(shape):
+    exp = Expander(threshold=-30.0, ratio=3.0, fs=FS)
+    x = torch.randn(*shape, dtype=torch.float64) * 0.1
+    assert exp(x).shape == x.shape
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_dtype_preserved(dtype):
+    exp = Expander(threshold=-30.0, ratio=4.0, fs=FS)
+    x = torch.randn(2, 4096, dtype=dtype) * 0.1
+    assert exp(x).dtype == dtype
+
+
+def test_identical_channels_identical_output():
+    exp = Expander(threshold=-30.0, ratio=4.0, fs=FS)
+    gen = torch.Generator().manual_seed(1)
+    mono = torch.randn(1, 8000, generator=gen, dtype=torch.float64) * 0.05
+    stereo = mono.repeat(2, 1)
+    y = exp(stereo)
+    torch.testing.assert_close(y[0], y[1])
+
+
+# --------------------------------------------------------------------------- #
+# Lazy fs + validation
+# --------------------------------------------------------------------------- #
+def test_fs_required():
+    exp = Expander(threshold=-30.0, ratio=4.0)
+    with pytest.raises(ValueError, match="Sample rate"):
+        exp(torch.randn(1, 1000))
+
+
+def test_fs_recompute_on_change():
+    exp = Expander(threshold=-30.0, ratio=4.0, fs=FS)
+    x = torch.randn(1, 4000, dtype=torch.float64) * 0.05
+    exp(x)
+    exp.fs = 96000
+    exp(x)  # recomputes coeffs without error
+    assert exp._last_fs == 96000
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"ratio": 0.5},
+        {"attack": -1.0},
+        {"release": -1.0},
+        {"knee": -1.0},
+        {"floor": 6.0},
+        {"detector": "bogus"},
+        {"fs": 0},
+    ],
+)
+def test_invalid_params_raise(kwargs):
+    with pytest.raises(ValueError):
+        Expander(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# Gate convenience subclass
+# --------------------------------------------------------------------------- #
+def test_gate_is_infinite_ratio_expander():
+    # attack=0 so the gate opens instantly (its default attack ramps over ~1 ms).
+    gate = Gate(threshold=-40.0, floor=-80.0, attack=0.0, fs=FS)
+    assert math.isinf(gate.ratio)
+    below = _const(10 ** (-50.0 / 20))
+    above = _const(10 ** (-20.0 / 20))
+    torch.testing.assert_close(gate(below), below * 10 ** (-80.0 / 20), rtol=1e-4, atol=1e-12)
+    torch.testing.assert_close(gate(above), above, rtol=1e-5, atol=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# CPU / CUDA parity
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("ratio", [4.0, float("inf")])
+@pytest.mark.parametrize("detector", ["peak", "rms"])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_cpu_cuda_parity(ratio, detector, dtype):
+    exp_cpu = Expander(threshold=-30.0, ratio=ratio, detector=detector, floor=-80.0, fs=FS)
+    exp_cuda = Expander(threshold=-30.0, ratio=ratio, detector=detector, floor=-80.0, fs=FS)
+    gen = torch.Generator().manual_seed(7)
+    x = torch.randn(8, 16000, generator=gen, dtype=dtype) * 0.05
+    y_cpu = exp_cpu(x)
+    y_cuda = exp_cuda(x.cuda()).cpu()
+    tol = {"rtol": 1e-4, "atol": 1e-5} if dtype == torch.float32 else {"rtol": 1e-9, "atol": 1e-10}
+    torch.testing.assert_close(y_cpu, y_cuda, **tol)

--- a/tests/test_expander.py
+++ b/tests/test_expander.py
@@ -218,10 +218,19 @@ def test_gate_is_infinite_ratio_expander():
 # CPU / CUDA parity
 # --------------------------------------------------------------------------- #
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-@pytest.mark.parametrize("ratio", [4.0, float("inf")])
 @pytest.mark.parametrize("detector", ["peak", "rms"])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
-def test_cpu_cuda_parity(ratio, detector, dtype):
+@pytest.mark.parametrize(
+    "ratio,dtype",
+    [
+        (4.0, torch.float32),
+        (4.0, torch.float64),
+        # A ratio=inf gate is a near-step transfer function; in float32 the detector's
+        # rounding (CPU-sequential vs CUDA) flips a few boundary samples between unity
+        # and floor, so per-sample parity is only meaningful in float64.
+        (float("inf"), torch.float64),
+    ],
+)
+def test_cpu_cuda_parity(ratio, dtype, detector):
     exp_cpu = Expander(threshold=-30.0, ratio=ratio, detector=detector, floor=-80.0, fs=FS)
     exp_cuda = Expander(threshold=-30.0, ratio=ratio, detector=detector, floor=-80.0, fs=FS)
     gen = torch.Generator().manual_seed(7)

--- a/tests/test_extract_changelog.py
+++ b/tests/test_extract_changelog.py
@@ -1,0 +1,98 @@
+"""Tests for the CHANGELOG release-notes extractor (issue #29)."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "tools" / "extract_changelog.py"
+
+
+def _load_extract():
+    spec = importlib.util.spec_from_file_location("extract_changelog", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.extract
+
+
+extract = _load_extract()
+
+SAMPLE = """# Changelog
+
+## [Unreleased]
+
+### Added
+
+- pending thing
+
+## [0.7.0] - 2026-06-09
+
+### Added
+
+- shiny feature
+
+### Fixed
+
+- a bug
+
+## [0.6.0] - 2026-06-04
+
+### Added
+
+- older feature
+"""
+
+
+def test_extract_middle_version():
+    out = extract(SAMPLE, "0.7.0")
+    assert "shiny feature" in out
+    assert "a bug" in out
+    assert "older feature" not in out  # stops at the next "## " header
+    assert "pending thing" not in out  # does not bleed into the previous section
+
+
+def test_extract_last_version_to_eof():
+    assert "older feature" in extract(SAMPLE, "0.6.0")
+
+
+def test_extract_unreleased():
+    assert "pending thing" in extract(SAMPLE, "Unreleased")
+
+
+def test_missing_version_raises():
+    with pytest.raises(KeyError):
+        extract(SAMPLE, "9.9.9")
+
+
+def test_cli_found(tmp_path):
+    cl = tmp_path / "CHANGELOG"
+    cl.write_text(SAMPLE)
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), "0.7.0", "--changelog", str(cl)],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0
+    assert "shiny feature" in res.stdout
+
+
+def test_cli_missing_exits_nonzero(tmp_path):
+    cl = tmp_path / "CHANGELOG"
+    cl.write_text(SAMPLE)
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), "9.9.9", "--changelog", str(cl)],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 1
+
+
+def test_real_changelog_section_non_empty():
+    text = (ROOT / "CHANGELOG").read_text(encoding="utf-8")
+    assert extract(text, "0.6.0").strip()

--- a/tests/test_fused_scan_equivalence.py
+++ b/tests/test_fused_scan_equivalence.py
@@ -1,0 +1,71 @@
+"""Equivalence of the fused per-section SOS path (Roadmap Epic 4.6 / paper C1).
+
+``TORCHFX_FUSED_SCAN=1`` switches ``sos_forward_cuda`` to the fused path that folds
+the FIR forcing into the scan (one kernel per section instead of forcing + scan).
+This checks the fused path reproduces the 3-phase oracle (same float order, so it
+should match very tightly) and ``scipy.signal.sosfilt``, across section count,
+channels, dtype, and both the sequential (``T <= threshold``) and parallel
+(``T > threshold``) branches — selected deterministically via ``threshold``.
+
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+import torch
+from scipy.signal import butter, sosfilt
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+# Force one branch or the other regardless of signal length.
+FORCE_SEQ = 1 << 30  # T <= huge -> sequential kernel
+FORCE_PAR = 0  # T <= 0 never true -> parallel scan
+
+
+def _cascade_sos(k: int) -> np.ndarray:
+    """K well-conditioned 2nd-order sections (varied cutoffs) -> [k, 6]."""
+    cutoffs = np.linspace(0.08, 0.45, k)
+    return np.concatenate([butter(2, float(c), output="sos") for c in cutoffs], axis=0)
+
+
+def _run(x: torch.Tensor, sos: torch.Tensor, threshold: int, fused: bool):
+    from torchfx._ops import parallel_iir_forward
+
+    prev = os.environ.get("TORCHFX_FUSED_SCAN")
+    os.environ["TORCHFX_FUSED_SCAN"] = "1" if fused else "0"
+    try:
+        y, _, _ = parallel_iir_forward(x, sos, None, None, sos_cpu=sos.cpu(), threshold=threshold)
+    finally:
+        if prev is None:
+            os.environ.pop("TORCHFX_FUSED_SCAN", None)
+        else:
+            os.environ["TORCHFX_FUSED_SCAN"] = prev
+    return y
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("k", [1, 3, 6])
+@pytest.mark.parametrize("c", [1, 4])
+@pytest.mark.parametrize("threshold", [FORCE_SEQ, FORCE_PAR])
+def test_fused_matches_oracle_and_scipy(dtype, k, c, threshold):
+    t = 3000  # spans both branches depending on `threshold`
+    g = torch.Generator().manual_seed(k * 100 + c)
+    x = torch.randn(c, t, generator=g, dtype=dtype)
+    sos_np = _cascade_sos(k)
+    sos = torch.tensor(sos_np, dtype=dtype, device="cuda")
+    xc = x.cuda()
+
+    oracle = _run(xc, sos, threshold, fused=False)
+    fused = _run(xc, sos, threshold, fused=True)
+
+    # Fused vs oracle: identical math in identical float order -> very tight.
+    tol = {"rtol": 1e-5, "atol": 1e-6} if dtype == torch.float32 else {"rtol": 1e-12, "atol": 1e-13}
+    torch.testing.assert_close(fused, oracle, **tol)
+
+    # Both vs scipy reference (CPU float64), looser float32 bound.
+    ref = torch.tensor(sosfilt(sos_np, x.double().numpy(), axis=-1), dtype=dtype)
+    stol = {"rtol": 2e-3, "atol": 2e-4} if dtype == torch.float32 else {"rtol": 1e-9, "atol": 1e-10}
+    torch.testing.assert_close(fused.cpu(), ref, **stol)

--- a/tests/test_fused_scan_equivalence.py
+++ b/tests/test_fused_scan_equivalence.py
@@ -69,3 +69,18 @@ def test_fused_matches_oracle_and_scipy(dtype, k, c, threshold):
     ref = torch.tensor(sosfilt(sos_np, x.double().numpy(), axis=-1), dtype=dtype)
     stol = {"rtol": 2e-3, "atol": 2e-4} if dtype == torch.float32 else {"rtol": 1e-9, "atol": 1e-10}
     torch.testing.assert_close(fused.cpu(), ref, **stol)
+
+
+@pytest.mark.parametrize("t", [50_000, 131_072])
+def test_fused_scan_forward_progress_large_t(t):
+    """Many tiles (~98 and 256) stress the decoupled-look-back forward progress."""
+    k, c, dtype = 4, 2, torch.float64
+    g = torch.Generator().manual_seed(t)
+    x = torch.randn(c, t, generator=g, dtype=dtype)
+    sos_np = _cascade_sos(k)
+    sos = torch.tensor(sos_np, dtype=dtype, device="cuda")
+    xc = x.cuda()
+
+    oracle = _run(xc, sos, FORCE_PAR, fused=False)
+    fused = _run(xc, sos, FORCE_PAR, fused=True)
+    torch.testing.assert_close(fused, oracle, rtol=1e-12, atol=1e-13)

--- a/tests/test_fused_scan_equivalence.py
+++ b/tests/test_fused_scan_equivalence.py
@@ -1,4 +1,4 @@
-"""Equivalence of the fused per-section SOS path (Roadmap Epic 4.6 / paper C1).
+"""Equivalence of the fused per-section SOS path (Roadmap Epic 4.6).
 
 ``TORCHFX_FUSED_SCAN=1`` switches ``sos_forward_cuda`` to the fused path that folds
 the FIR forcing into the scan (one kernel per section instead of forcing + scan).

--- a/tests/test_limiter.py
+++ b/tests/test_limiter.py
@@ -1,0 +1,159 @@
+"""Tests for the look-ahead brick-wall Limiter (issue #31)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from torchfx.effect import Limiter
+
+FS = 48000
+
+
+def _thr_lin(db: float) -> float:
+    return 10 ** (db / 20)
+
+
+# --------------------------------------------------------------------------- #
+# Brick-wall guarantee: |y| never exceeds the ceiling
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("thr_db", [-1.0, -6.0, -12.0])
+@pytest.mark.parametrize("scale", [0.5, 1.0, 3.0, 10.0])
+def test_brickwall_never_exceeds_threshold(thr_db, scale):
+    lim = Limiter(threshold=thr_db, lookahead=0.005, release=0.05, fs=FS)
+    gen = torch.Generator().manual_seed(0)
+    x = torch.randn(2, 24000, generator=gen, dtype=torch.float64) * scale
+    y = lim(x)
+    assert y.abs().max().item() <= _thr_lin(thr_db) + 1e-9
+
+
+def test_brickwall_on_transients():
+    lim = Limiter(threshold=-6.0, lookahead=0.003, release=0.02, fs=FS)
+    x = torch.full((1, 10000), 0.2, dtype=torch.float64)
+    x[0, 5000] = 8.0  # single-sample spike far over full scale
+    x[0, 2000:2100] = 3.0  # a loud burst
+    y = lim(x)
+    assert y.abs().max().item() <= _thr_lin(-6.0) + 1e-9
+
+
+def test_brickwall_on_sine_over_full_scale():
+    lim = Limiter(threshold=-1.0, lookahead=0.005, release=0.05, fs=FS)
+    t = torch.arange(48000, dtype=torch.float64) / FS
+    x = (3.0 * torch.sin(2 * torch.pi * 220 * t)).unsqueeze(0)
+    y = lim(x)
+    assert y.abs().max().item() <= _thr_lin(-1.0) + 1e-9
+
+
+def test_lookahead_zero_still_brickwall():
+    lim = Limiter(threshold=-3.0, lookahead=0.0, release=0.05, fs=FS)
+    gen = torch.Generator().manual_seed(2)
+    x = torch.randn(1, 8000, generator=gen, dtype=torch.float64) * 2.0
+    y = lim(x)
+    assert y.abs().max().item() <= _thr_lin(-3.0) + 1e-9
+
+
+# --------------------------------------------------------------------------- #
+# Transparency + look-ahead behaviour
+# --------------------------------------------------------------------------- #
+def test_below_threshold_passes_through():
+    lim = Limiter(threshold=-1.0, lookahead=0.005, release=0.05, fs=FS)
+    gen = torch.Generator().manual_seed(3)
+    x = torch.randn(1, 8000, generator=gen, dtype=torch.float64) * 0.1  # peaks well below ceiling
+    assert x.abs().max().item() < _thr_lin(-1.0)
+    torch.testing.assert_close(lim(x), x, rtol=1e-9, atol=1e-12)
+
+
+def test_lookahead_reduces_gain_before_peak():
+    L = round(0.005 * FS)  # 240
+    spike_at = 2000
+    base = 0.3  # below the -6 dB ceiling (~0.501)
+    x = torch.full((1, 4000), base, dtype=torch.float64)
+    x[0, spike_at] = 5.0
+    y_la = Limiter(threshold=-6.0, lookahead=0.005, release=0.05, fs=FS)(x)
+    y_no = Limiter(threshold=-6.0, lookahead=0.0, release=0.05, fs=FS)(x)
+    # With look-ahead the gain is already pulling down within the window before the spike;
+    # without it the pre-spike samples (below threshold) are untouched.
+    assert y_la[0, spike_at - L // 2].abs().item() < 0.9 * base
+    assert y_no[0, spike_at - L // 2].abs().item() == pytest.approx(base, rel=1e-9)
+
+
+def test_release_recovers_after_peak():
+    lim = Limiter(threshold=-6.0, lookahead=0.002, release=0.03, fs=FS)
+    loud = torch.full((1, 2000), 4.0, dtype=torch.float64)
+    quiet = torch.full((1, 16000), 0.2, dtype=torch.float64)  # below ceiling
+    x = torch.cat([loud, quiet], dim=1)
+    y = lim(x)
+    g_tail = y[0, 2000:].abs() / x[0, 2000:].abs()
+    assert g_tail[0].item() < 0.9  # still attenuated right after the loud part
+    assert g_tail[-1].item() == pytest.approx(1.0, abs=1e-3)  # recovered (one-pole asymptote)
+
+
+# --------------------------------------------------------------------------- #
+# Shapes, dtypes, channels
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("shape", [(4096,), (2, 4096), (3, 2, 4096)])
+def test_shapes_preserved(shape):
+    lim = Limiter(threshold=-1.0, fs=FS)
+    x = torch.randn(*shape, dtype=torch.float64) * 2.0
+    y = lim(x)
+    assert y.shape == x.shape
+    assert y.abs().max().item() <= _thr_lin(-1.0) + 1e-9
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_dtype_preserved_and_brickwall(dtype):
+    lim = Limiter(threshold=-2.0, fs=FS)
+    x = torch.randn(2, 8000, dtype=dtype) * 2.0
+    y = lim(x)
+    assert y.dtype == dtype
+    eps = 1e-5 if dtype == torch.float32 else 1e-9
+    assert y.abs().max().item() <= _thr_lin(-2.0) + eps
+
+
+def test_identical_channels_identical_output():
+    lim = Limiter(threshold=-3.0, fs=FS)
+    gen = torch.Generator().manual_seed(4)
+    mono = torch.randn(1, 8000, generator=gen, dtype=torch.float64) * 2.0
+    y = lim(mono.repeat(2, 1))
+    torch.testing.assert_close(y[0], y[1])
+
+
+# --------------------------------------------------------------------------- #
+# Lazy fs + validation
+# --------------------------------------------------------------------------- #
+def test_fs_required():
+    with pytest.raises(ValueError, match="Sample rate"):
+        Limiter(threshold=-1.0)(torch.randn(1, 1000))
+
+
+def test_fs_recompute_on_change():
+    lim = Limiter(threshold=-1.0, fs=FS)
+    x = torch.randn(1, 4000, dtype=torch.float64) * 2.0
+    lim(x)
+    lim.fs = 96000
+    lim(x)
+    assert lim._last_fs == 96000
+    assert lim._lookahead_samples == round(0.005 * 96000)
+
+
+@pytest.mark.parametrize("kwargs", [{"lookahead": -1.0}, {"release": -1.0}, {"fs": 0}])
+def test_invalid_params_raise(kwargs):
+    with pytest.raises(ValueError):
+        Limiter(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# CPU / CUDA parity
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("lookahead", [0.0, 0.005])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_cpu_cuda_parity(lookahead, dtype):
+    lim_cpu = Limiter(threshold=-3.0, lookahead=lookahead, release=0.05, fs=FS)
+    lim_cuda = Limiter(threshold=-3.0, lookahead=lookahead, release=0.05, fs=FS)
+    gen = torch.Generator().manual_seed(7)
+    x = torch.randn(8, 16000, generator=gen, dtype=dtype) * 2.0
+    y_cpu = lim_cpu(x)
+    y_cuda = lim_cuda(x.cuda()).cpu()
+    tol = {"rtol": 1e-4, "atol": 1e-5} if dtype == torch.float32 else {"rtol": 1e-9, "atol": 1e-10}
+    torch.testing.assert_close(y_cpu, y_cuda, **tol)

--- a/tests/test_perf_regression.py
+++ b/tests/test_perf_regression.py
@@ -1,0 +1,163 @@
+"""Performance-regression gates (issue #21).
+
+CI runners are shared and noisy, so an absolute wall-time budget against a stored baseline
+is flaky. These gates instead assert the *deterministic* invariants that the headline perf
+wins depend on — the fusion planner must keep collapsing a depth-K IIR cascade (and a
+static ``Gain`` folded between sections) into a **single** native dispatch — plus one
+**relative** wall-time smoke (fused is not dramatically slower than the unfused path),
+which is machine-speed-independent and has a large margin. If fusion silently regresses,
+the dispatch count jumps and these fail in ordinary CI.
+
+The dispatch count is measured by wrapping the ``torchfx._ops`` dispatch functions, the
+same mechanism as ``tools/count_kernel_launches.py``.
+
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from functools import reduce
+from typing import Any
+
+import pytest
+import torch
+
+from torchfx import Wave, _ops
+from torchfx.effect import Gain
+from torchfx.filter.iir import HiButterworth, LoButterworth
+
+FS = 16000
+N = 8192
+
+
+@contextmanager
+def count_native():
+    """Count Python-level dispatches into the native extension (biquad / sos /
+    delay)."""
+    counts = {"biquad": 0, "sos": 0, "delay": 0}
+    originals = (_ops.biquad_forward, _ops.parallel_iir_forward, _ops.delay_line_forward)
+
+    def make(key: str, fn: Any) -> Any:
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            counts[key] += 1
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    _ops.biquad_forward = make("biquad", originals[0])
+    _ops.parallel_iir_forward = make("sos", originals[1])
+    _ops.delay_line_forward = make("delay", originals[2])
+    try:
+        yield counts
+    finally:
+        _ops.biquad_forward, _ops.parallel_iir_forward, _ops.delay_line_forward = originals
+
+
+def _wave() -> Wave:
+    gen = torch.Generator().manual_seed(0)
+    return Wave(torch.randn(1, N, generator=gen, dtype=torch.float64), FS)
+
+
+def _filters(k: int) -> list:
+    out = []
+    for i in range(k):
+        if i % 2 == 0:
+            out.append(LoButterworth(cutoff=2000 + 200 * i, order=2))
+        else:
+            out.append(HiButterworth(cutoff=100 + 10 * i, order=2))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic fusion-dispatch invariants (the perf-regression core)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("k", [2, 5, 10])
+def test_fused_chain_is_single_dispatch(k):
+    """A depth-K IIR cascade must fuse to exactly one native SOS dispatch."""
+    wave = _wave()
+    chain = reduce(lambda a, b: a | b, _filters(k))
+    with count_native() as counts:
+        _ = (wave | chain).ys
+    assert counts["sos"] == 1, f"depth-{k} cascade should fuse to 1 SOS dispatch, got {counts}"
+    assert counts["biquad"] == 0
+
+
+@pytest.mark.parametrize("k", [2, 5, 10])
+def test_unfused_chain_is_k_dispatches(k):
+    """The reference (each filter applied separately) issues K dispatches — the baseline
+    the fused path must keep beating."""
+    wave = _wave()
+    filters = _filters(k)
+    for f in filters:
+        f.fs = FS
+        f.compute_coefficients()
+    data = wave.ys.clone()
+    with count_native() as counts:
+        for f in filters:
+            data = f(data)
+    assert counts["sos"] == k
+
+
+def test_static_gain_between_iir_folds_to_single_dispatch():
+    """A constant `Gain` between two IIR filters must fold into the cascade (0.6.0 win),
+    so the chain still collapses to one dispatch."""
+    wave = _wave()
+    chain = LoButterworth(cutoff=4000, order=4) | Gain(2.0) | LoButterworth(cutoff=6000, order=4)
+    with count_native() as counts:
+        _ = (wave | chain).ys
+    assert counts["sos"] == 1, f"a folded Gain must not add a dispatch, got {counts}"
+
+
+# --------------------------------------------------------------------------- #
+# Relative wall-time smoke (machine-independent, large margin -> not flaky)
+# --------------------------------------------------------------------------- #
+def _median_wall(fn, *, warmup=3, iters=15) -> float:
+    for _ in range(warmup):
+        fn()
+    samples = []
+    for _ in range(iters):
+        t0 = time.perf_counter_ns()
+        fn()
+        samples.append(time.perf_counter_ns() - t0)
+    samples.sort()
+    return samples[len(samples) // 2]
+
+
+def test_fused_forward_not_slower_than_unfused():
+    """Compare *forward* cost only (both modules pre-built): the fused single-dispatch
+    cascade must not be slower than K separate filter forwards.
+
+    Normally it is several times faster, so the margin (fused < 1.1x unfused) keeps this
+    robust on noisy CI.
+
+    """
+    k = 10
+    data = _wave().ys.clone()
+
+    # Fused module, built once via the planner.
+    fused_filters = _filters(k)
+    for f in fused_filters:
+        f.fs = FS
+    plan = Wave._build_plan(fused_filters)
+    assert len(plan) == 1  # the whole chain collapsed
+    fused_mod = plan[0]
+
+    # Unfused: K prepared filters applied in sequence.
+    sep = _filters(k)
+    for f in sep:
+        f.fs = FS
+        f.compute_coefficients()
+
+    def run_fused():
+        return fused_mod(data)
+
+    def run_unfused():
+        d = data
+        for f in sep:
+            d = f(d)
+        return d
+
+    fused = _median_wall(run_fused)
+    unfused = _median_wall(run_unfused)
+    assert fused < unfused * 1.1, f"fused={fused}ns vs unfused={unfused}ns — fusion regressed"

--- a/tests/test_reverb.py
+++ b/tests/test_reverb.py
@@ -1,0 +1,118 @@
+"""Tests for the Freeverb-style Reverb effect (issue #18)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from torchfx.effect import Reverb
+
+FS = 48000
+
+
+def _impulse(n: int = FS, c: int = 1, dtype=torch.float64) -> torch.Tensor:
+    x = torch.zeros(c, n, dtype=dtype)
+    x[:, 0] = 1.0
+    return x
+
+
+# --------------------------------------------------------------------------- #
+# Stability + reverb tail
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("room", [0.0, 0.5, 0.95])
+@pytest.mark.parametrize("damp", [0.0, 0.5, 1.0])
+def test_stable_and_finite(room, damp):
+    rev = Reverb(room_size=room, damping=damp, mix=1.0, fs=FS)
+    y = rev(_impulse())
+    assert torch.isfinite(y).all()
+    assert y.abs().max() < 10.0  # bounded (no runaway feedback)
+
+
+def test_impulse_produces_decaying_tail():
+    rev = Reverb(room_size=0.85, damping=0.3, mix=1.0, fs=FS)
+    y = rev(_impulse())[0]
+    assert (y[2000:] ** 2).sum() > 0  # there is a tail
+    assert y[40000:].abs().max() < y[:4000].abs().max()  # and it decays
+
+
+def test_larger_room_has_longer_tail():
+    small = Reverb(room_size=0.2, damping=0.2, mix=1.0, fs=FS)(_impulse())[0]
+    large = Reverb(room_size=0.95, damping=0.2, mix=1.0, fs=FS)(_impulse())[0]
+    # Energy in the late tail grows with room size (longer decay).
+    assert (large[24000:] ** 2).sum() > (small[24000:] ** 2).sum()
+
+
+def test_damping_changes_output():
+    bright = Reverb(room_size=0.8, damping=0.0, mix=1.0, fs=FS)(_impulse())
+    dark = Reverb(room_size=0.8, damping=1.0, mix=1.0, fs=FS)(_impulse())
+    assert not torch.allclose(bright, dark)
+
+
+# --------------------------------------------------------------------------- #
+# Wet/dry mix
+# --------------------------------------------------------------------------- #
+def test_mix_zero_is_dry():
+    x = torch.randn(2, 8000, dtype=torch.float64)
+    torch.testing.assert_close(Reverb(mix=0.0, fs=FS)(x), x, rtol=1e-12, atol=1e-13)
+
+
+def test_mix_interpolates_linearly():
+    x = _impulse(n=8000)
+    full = Reverb(room_size=0.8, mix=1.0, fs=FS)(x)
+    half = Reverb(room_size=0.8, mix=0.5, fs=FS)(x)
+    expected_half = 0.5 * x + 0.5 * full  # dry=1-mix, wet=mix on the same wet signal
+    torch.testing.assert_close(half, expected_half, rtol=1e-9, atol=1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# Shapes, dtypes, channels
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("shape", [(8000,), (2, 8000), (3, 2, 8000)])
+def test_shapes_preserved(shape):
+    y = Reverb(fs=FS)(torch.randn(*shape, dtype=torch.float64))
+    assert y.shape == shape
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_dtype_preserved(dtype):
+    y = Reverb(fs=FS)(torch.randn(2, 8000, dtype=dtype))
+    assert y.dtype == dtype
+
+
+def test_identical_channels_identical_output():
+    mono = _impulse(n=8000)
+    y = Reverb(room_size=0.8, fs=FS)(mono.repeat(2, 1))
+    torch.testing.assert_close(y[0], y[1])
+
+
+# --------------------------------------------------------------------------- #
+# Lazy fs + validation
+# --------------------------------------------------------------------------- #
+def test_fs_required():
+    with pytest.raises(ValueError, match="Sample rate"):
+        Reverb()(torch.randn(1, 1000))
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [{"room_size": -0.1}, {"room_size": 1.1}, {"damping": 2.0}, {"mix": -1.0}, {"fs": 0}],
+)
+def test_invalid_params_raise(kwargs):
+    with pytest.raises(ValueError):
+        Reverb(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# CPU / CUDA parity
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_cpu_cuda_parity(dtype):
+    rev_cpu = Reverb(room_size=0.8, damping=0.4, mix=0.3, fs=FS)
+    rev_cuda = Reverb(room_size=0.8, damping=0.4, mix=0.3, fs=FS)
+    gen = torch.Generator().manual_seed(5)
+    x = torch.randn(4, 16000, generator=gen, dtype=dtype)
+    y_cpu = rev_cpu(x)
+    y_cuda = rev_cuda(x.cuda()).cpu()
+    tol = {"rtol": 2e-3, "atol": 2e-4} if dtype == torch.float32 else {"rtol": 1e-9, "atol": 1e-10}
+    torch.testing.assert_close(y_cpu, y_cuda, **tol)

--- a/tests/test_simd_sos.py
+++ b/tests/test_simd_sos.py
@@ -1,0 +1,91 @@
+"""Cross-channel SIMD CPU SOS path equivalence (issue #24).
+
+``TORCHFX_FORCE_SIMD=1`` engages the cache-blocked cross-channel SIMD kernel at any
+channel count; ``TORCHFX_NO_SIMD=1`` forces the scalar path. This checks the SIMD path
+reproduces the scalar kernel and ``scipy.signal.sosfilt`` across channel counts
+(including partial SIMD groups), section counts, and dtypes, and that it carries
+streaming state correctly across chunks.
+
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+import torch
+from scipy.signal import butter, sosfilt
+
+
+def _run(x, sos, simd: bool):
+    from torchfx._ops import parallel_iir_forward
+
+    keep = {k: os.environ.get(k) for k in ("TORCHFX_NO_SIMD", "TORCHFX_FORCE_SIMD")}
+    os.environ.pop("TORCHFX_NO_SIMD", None)
+    os.environ.pop("TORCHFX_FORCE_SIMD", None)
+    os.environ["TORCHFX_FORCE_SIMD" if simd else "TORCHFX_NO_SIMD"] = "1"
+    try:
+        y, sx, sy = parallel_iir_forward(x, sos, None, None, sos_cpu=sos)
+    finally:
+        for k, v in keep.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+    return y, sx, sy
+
+
+def _cascade(k: int) -> np.ndarray:
+    return np.concatenate([butter(2, c, output="sos") for c in np.linspace(0.1, 0.4, k)], axis=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("k", [1, 3, 6])
+@pytest.mark.parametrize("c", [1, 2, 3, 4, 5, 7, 8, 9, 16, 17])
+def test_simd_matches_scalar_and_scipy(dtype, k, c):
+    t = 2000
+    sos_np = _cascade(k)
+    g = torch.Generator().manual_seed(k * 100 + c)
+    x = torch.randn(c, t, generator=g, dtype=dtype)
+    sos = torch.tensor(sos_np, dtype=dtype)
+
+    scalar, _, _ = _run(x, sos, simd=False)
+    simd, _, _ = _run(x, sos, simd=True)
+
+    # Same math, same order -> tight; both within a float bound of the scipy reference.
+    tol = {"rtol": 1e-5, "atol": 1e-6} if dtype == torch.float32 else {"rtol": 1e-12, "atol": 1e-13}
+    torch.testing.assert_close(simd, scalar, **tol)
+    ref = torch.tensor(sosfilt(sos_np, x.double().numpy(), axis=-1), dtype=dtype)
+    stol = {"rtol": 2e-3, "atol": 2e-4} if dtype == torch.float32 else {"rtol": 1e-9, "atol": 1e-10}
+    torch.testing.assert_close(simd.cpu(), ref, **stol)
+
+
+def test_simd_streaming_state_continuity():
+    """Chunked streaming through the SIMD path == whole-signal processing."""
+    from torchfx._ops import parallel_iir_forward
+
+    c, k, t = 16, 3, 4096  # C > typical core count so the SIMD path is exercised
+    sos_np = _cascade(k)
+    g = torch.Generator().manual_seed(0)
+    x = torch.randn(c, t, dtype=torch.float64, generator=g)
+    sos = torch.tensor(sos_np, dtype=torch.float64)
+
+    whole, _, _ = _run(x, sos, simd=True)
+
+    prev = os.environ.get("TORCHFX_FORCE_SIMD")
+    os.environ["TORCHFX_FORCE_SIMD"] = "1"
+    try:
+        sx = sy = None
+        outs = []
+        for chunk in x.split(700, dim=1):
+            y, sx, sy = parallel_iir_forward(chunk, sos, sx, sy, sos_cpu=sos)
+            outs.append(y)
+        streamed = torch.cat(outs, dim=1)
+    finally:
+        if prev is None:
+            os.environ.pop("TORCHFX_FORCE_SIMD", None)
+        else:
+            os.environ["TORCHFX_FORCE_SIMD"] = prev
+
+    torch.testing.assert_close(streamed, whole, rtol=1e-12, atol=1e-13)

--- a/tools/extract_changelog.py
+++ b/tools/extract_changelog.py
@@ -1,0 +1,62 @@
+"""Extract one version's section from the CHANGELOG, for GitHub release notes.
+
+The release workflow (``.github/workflows/release.yml``) runs this on the version it is
+tagging and feeds the output to ``gh release create --notes-file``. Given a ``CHANGELOG``
+with `Keep a Changelog`-style headers::
+
+    ## [0.7.0] - 2026-06-09
+    ### Added
+    - ...
+
+    ## [0.6.0] - 2026-06-04
+    ...
+
+``extract_changelog.py 0.7.0`` prints everything under ``## [0.7.0]`` up to (but not
+including) the next ``## `` header.
+
+Usage::
+
+    python tools/extract_changelog.py 0.7.0 [--changelog CHANGELOG]
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def extract(changelog: str, version: str) -> str:
+    """Return the release-notes body for ``version`` (raises ``KeyError`` if absent)."""
+    header = re.compile(r"^## \[" + re.escape(version) + r"\]")
+    lines = changelog.splitlines()
+    start = next((i for i, line in enumerate(lines) if header.match(line)), None)
+    if start is None:
+        raise KeyError(f"No CHANGELOG section for version {version!r}.")
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        if line.startswith("## "):
+            break
+        body.append(line)
+    return "\n".join(body).strip("\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="version to extract, e.g. 0.7.0 (no leading 'v')")
+    parser.add_argument("--changelog", default="CHANGELOG", help="path to the changelog file")
+    args = parser.parse_args(argv)
+
+    text = Path(args.changelog).read_text(encoding="utf-8")
+    try:
+        print(extract(text, args.version))
+    except KeyError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -2737,7 +2737,7 @@ wheels = [
 
 [[package]]
 name = "torchfx"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-types" },


### PR DESCRIPTION
Promotes `dev` to `master` to **release v0.7.0**.

⚠️ **Merging this fires the automated release** (`release.yml`): it tags `v0.7.0`, the wheel workflows publish to **PyPI** + the CUDA wheel index, and a **GitHub Release** is created from the `## [0.7.0]` CHANGELOG section. `pyproject` is already at `0.7.0`.

> Merge **#82 (the 0.7.0 blog post)** into `dev` first so it ships with the release.

## v0.7.0 highlights
- **Dynamics suite** — `Compressor`, `Expander`/`Gate`, look-ahead brick-wall `Limiter` (native per-channel C++/CUDA).
- **Freeverb reverb** — 8 parallel combs + 4 series all-passes (replaces the single-comb reverb; **breaking** `Reverb` API).
- **Single-pass GPU SOS scan** — decoupled-look-back kernel, 5.9× fewer launches, ~1.9× faster; now the default.
- **Cache-blocked cross-channel CPU SIMD** — 1.8–2.6× on a Raspberry Pi 5, 1.3–2.4× on x86, no regression below the gate.
- **`batch_process`** — many signals in one launch (~2.5–7× CPU, ~3–4× GPU).
- **Tooling** — automated releases + CHANGELOG release notes, perf-regression CI gates, Codecov config, profiling guide, CUDA-wheel disk fix.

Full notes: the `[0.7.0]` section of the [CHANGELOG](https://github.com/matteospanio/torchfx/blob/master/CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)