### PR TITLE
IS² review fixes: stale-coeff guards, streaming state for dynamics/reverb, DDSP PoC

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Streaming state for the dynamics effects and the reverb (#72, #86).**
+  `Compressor`, `Expander`/`Gate`, `Limiter`, and `Reverb` now carry their
+  per-channel recurrence state across `forward()` calls: the native kernels
+  (CPU + CUDA) thread detector ballistics `(y1, yL, ms)`, the limiter's
+  smoothed gain, and the reverb's comb/all-pass delay lines + ring positions
+  through optional state tensors. Block-wise/chunked processing is now
+  bit-identical to one-shot processing (limiter: exact for `lookahead=0`;
+  the look-ahead window does not cross chunk boundaries, the per-sample
+  clamp still guarantees the ceiling). All four effects gained
+  `reset_state()`; `Wave` materialisation and `StreamProcessor` boundaries
+  reset automatically, so offline use is unchanged.
+- **Differentiable-DSP proof of concept** (`examples/ddsp_graphic_eq.py`):
+  a learnable RBJ parametric EQ (per-band cutoff/Q/gain as `nn.Parameter`)
+  applied in the frequency domain and trained with a multi-resolution STFT
+  loss to invert an unknown coloration — gradients flow end-to-end through
+  the SOS parameterisation with plain autograd (the fast `no_grad` inference
+  kernels are untouched). Converges to a 0.04 dB mean-abs residual inverse
+  in ~120 Adam steps on CPU.
+- Regression tests: `tests/test_streaming_state.py` (chunked-vs-oneshot
+  equality, tail continuity, reset/self-heal semantics, Wave isolation) and
+  `tests/test_review_fixes.py` (IS²-review fixes #84–#96).
+
+### Fixed
+
+- **`FusedSOSCascade` recomputes on `fs` change (#84).** The fused cascade
+  now tracks `_coeff_fs`, keeps its source filters, and rebuilds the
+  concatenated SOS matrix (re-applying the folded gain) when the sampling
+  rate changes after construction — previously a `RealtimeProcessor`-style
+  `effect.fs = ...` assignment silently kept coefficients designed for the
+  old rate.
+- **`DesignableFIR` redesigns on the direct path (#85).** `forward()` now
+  redesigns when `fs` or a design parameter changed and raises instead of
+  silently passing audio through its placeholder kernel when `fs` is unset.
+- **Post-design parameter mutation detected (#88).** `IIR`, `Biquad`, and
+  `DesignableFIR` snapshot their design parameters and redesign when e.g.
+  `cutoff`/`order`/`q` are mutated after the first forward.
+- **Realtime callback no longer allocates (#87).** The input numpy view and
+  the empty placeholder tensor are pre-allocated outside the PortAudio
+  callback.
+- `MusicalTime.duration_seconds` raises `ValueError` (not `assert`) on
+  non-positive BPM (#91); `validate_q_factor` dead condition removed (#95);
+  `Wave.merge` validates same-device like it validates `fs` (#93);
+  `batch_process` rejects channel-coupled effects such as a global-peak
+  `Normalize` (#92); `Normalize` no longer type-erases strategy instances
+  by wrapping them in `CustomNormalizationStrategy`.
+- CUDA hardening: explicit `int` casts + 32-bit indexing guard in
+  `delay_forward.cu`, epoch-tag wrap guard in the fused-scan path (#89,
+  #96). Ring-buffer docs now state the GIL-dependence of the lockless SPSC
+  design (#94).
+
 ## [0.7.0] - 2026-06-09
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,18 +100,14 @@ if(TORCHFX_USE_CUDA)
   target_compile_definitions(torchfx_ext PRIVATE WITH_CUDA)
   set_target_properties(torchfx_ext PROPERTIES CUDA_ARCHITECTURES "${TORCHFX_CUDA_ARCHS}")
 
-  # nvcc >= 13.3 rejects torch 2.10's own headers (ATen/core/List_inl.h:
-  # "need 'typename' before 'decltype'") as a hard error under its stricter
-  # host-compiler invocation; 12.x / 13.2 accept them. Relax the CUDA host
-  # compile (GCC only, .cu sources only) so the toolkit-vs-torch mismatch is a
-  # warning, not a build failure. Scoped to the affected nvcc line so known-good
-  # toolchains (CI cu124, workstation 12.4) are untouched. Remove once torch
-  # ships conformant headers.
-  if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 13.3)
-    message(STATUS "nvcc ${CMAKE_CUDA_COMPILER_VERSION}: adding -Xcompiler=-fpermissive for torch-header compat")
-    target_compile_options(torchfx_ext PRIVATE
-      $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-fpermissive>)
-  endif()
+  # Compatibility note: nvcc 13.3 fails to compile torch 2.10's own headers
+  # (ATen/core/List_inl.h:202 "need 'typename' before 'decltype'"); nvcc <= 13.2
+  # and the cu124/cu128 toolkits accept them. This is a torch-vs-toolkit version
+  # issue, not a flag we can paper over: a probe on the affected node confirmed
+  # neither -Xcompiler=-fpermissive (host pass) nor -Xcudafe --diag_suppress
+  # (device front-end) suppresses the hard parse error. Build with an nvcc whose
+  # CUDA version matches torch's (here 12.8 / cu128), i.e. nvcc <= 13.2. The
+  # cluster sbatch scripts select a matching toolkit; see benchmarks/slurm/.
 endif()
 
 target_include_directories(torchfx_ext PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,19 @@ if(TORCHFX_USE_CUDA)
     "${CSRC_DIR}/cuda/reverb_forward.cu")
   target_compile_definitions(torchfx_ext PRIVATE WITH_CUDA)
   set_target_properties(torchfx_ext PROPERTIES CUDA_ARCHITECTURES "${TORCHFX_CUDA_ARCHS}")
+
+  # nvcc >= 13.3 rejects torch 2.10's own headers (ATen/core/List_inl.h:
+  # "need 'typename' before 'decltype'") as a hard error under its stricter
+  # host-compiler invocation; 12.x / 13.2 accept them. Relax the CUDA host
+  # compile (GCC only, .cu sources only) so the toolkit-vs-torch mismatch is a
+  # warning, not a build failure. Scoped to the affected nvcc line so known-good
+  # toolchains (CI cu124, workstation 12.4) are untouched. Remove once torch
+  # ships conformant headers.
+  if(CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 13.3)
+    message(STATUS "nvcc ${CMAKE_CUDA_COMPILER_VERSION}: adding -Xcompiler=-fpermissive for torch-header compat")
+    target_compile_options(torchfx_ext PRIVATE
+      $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-fpermissive>)
+  endif()
 endif()
 
 target_include_directories(torchfx_ext PRIVATE

--- a/benchmarks/profiles/scenarios.py
+++ b/benchmarks/profiles/scenarios.py
@@ -134,7 +134,7 @@ def _build_realtime_gpu(device: str) -> nn.Module:
     chain = nn.Sequential(
         BiquadBPF(cutoff=1_000, q=1.2, fs=SAMPLE_RATE),
         Delay(delay_samples=int(SAMPLE_RATE * 0.25), feedback=0.3, mix=0.4, fs=SAMPLE_RATE),
-        Reverb(decay=0.5, mix=0.3, delay=int(SAMPLE_RATE * 0.05)),
+        Reverb(room_size=0.5, damping=0.5, mix=0.3, fs=SAMPLE_RATE),
     )
     for m in chain:
         if hasattr(m, "compute_coefficients"):

--- a/benchmarks/slurm/bench_a40.sbatch
+++ b/benchmarks/slurm/bench_a40.sbatch
@@ -23,9 +23,19 @@ cd "${SLURM_SUBMIT_DIR:-$PWD}"
 # PATH by default. CUDA_HOME drives CMake's find_package(CUDAToolkit) when
 # scikit-build-core builds the .cu kernels. UV_LINK_MODE=copy silences the
 # hardlink-cross-filesystem warning between /nfsd and the build cache.
-export PATH="/usr/local/cuda/bin:$PATH"
+# Prefer a known-good CUDA toolkit over the /usr/local/cuda symlink: the gpu7
+# upgrade to nvcc 13.3 (2026-06) broke compilation of torch 2.10's own headers
+# (ATen/core/List_inl.h: "need 'typename' before 'decltype'"); 13.2 builds
+# cleanly. Fall back to the symlink only when no pinned version exists.
+for _cuda_v in 13.2 12.9 12.8 12.6 12.4; do
+  if [ -x "/usr/local/cuda-${_cuda_v}/bin/nvcc" ]; then
+    export CUDA_HOME="/usr/local/cuda-${_cuda_v}"
+    break
+  fi
+done
 export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
-export CUDACXX="${CUDACXX:-/usr/local/cuda/bin/nvcc}"
+export CUDACXX="${CUDACXX:-$CUDA_HOME/bin/nvcc}"
+export PATH="$CUDA_HOME/bin:$PATH"
 export UV_LINK_MODE=copy
 # Keep uv's cache + build temp off the (quota-limited) home filesystem.
 export UV_CACHE_DIR="${UV_CACHE_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/.uvcache}"

--- a/benchmarks/slurm/bench_l40s.sbatch
+++ b/benchmarks/slurm/bench_l40s.sbatch
@@ -32,9 +32,19 @@ cd "${SLURM_SUBMIT_DIR:-$PWD}"
 # PATH by default. CUDA_HOME drives CMake's find_package(CUDAToolkit) when
 # scikit-build-core builds the .cu kernels. UV_LINK_MODE=copy silences the
 # hardlink-cross-filesystem warning between /nfsd and the build cache.
-export PATH="/usr/local/cuda/bin:$PATH"
+# Prefer a known-good CUDA toolkit over the /usr/local/cuda symlink: the gpu7
+# upgrade to nvcc 13.3 (2026-06) broke compilation of torch 2.10's own headers
+# (ATen/core/List_inl.h: "need 'typename' before 'decltype'"); 13.2 builds
+# cleanly. Fall back to the symlink only when no pinned version exists.
+for _cuda_v in 13.2 12.9 12.8 12.6 12.4; do
+  if [ -x "/usr/local/cuda-${_cuda_v}/bin/nvcc" ]; then
+    export CUDA_HOME="/usr/local/cuda-${_cuda_v}"
+    break
+  fi
+done
 export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
-export CUDACXX="${CUDACXX:-/usr/local/cuda/bin/nvcc}"
+export CUDACXX="${CUDACXX:-$CUDA_HOME/bin/nvcc}"
+export PATH="$CUDA_HOME/bin:$PATH"
 export UV_LINK_MODE=copy
 # Keep uv's cache + build temp off the (quota-limited) home filesystem.
 export UV_CACHE_DIR="${UV_CACHE_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/.uvcache}"

--- a/benchmarks/slurm/bench_rtx.sbatch
+++ b/benchmarks/slurm/bench_rtx.sbatch
@@ -24,9 +24,19 @@ cd "${SLURM_SUBMIT_DIR:-$PWD}"
 # PATH by default. CUDA_HOME drives CMake's find_package(CUDAToolkit) when
 # scikit-build-core builds the .cu kernels. UV_LINK_MODE=copy silences the
 # hardlink-cross-filesystem warning between /nfsd and the build cache.
-export PATH="/usr/local/cuda/bin:$PATH"
+# Prefer a known-good CUDA toolkit over the /usr/local/cuda symlink: the gpu7
+# upgrade to nvcc 13.3 (2026-06) broke compilation of torch 2.10's own headers
+# (ATen/core/List_inl.h: "need 'typename' before 'decltype'"); 13.2 builds
+# cleanly. Fall back to the symlink only when no pinned version exists.
+for _cuda_v in 13.2 12.9 12.8 12.6 12.4; do
+  if [ -x "/usr/local/cuda-${_cuda_v}/bin/nvcc" ]; then
+    export CUDA_HOME="/usr/local/cuda-${_cuda_v}"
+    break
+  fi
+done
 export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
-export CUDACXX="${CUDACXX:-/usr/local/cuda/bin/nvcc}"
+export CUDACXX="${CUDACXX:-$CUDA_HOME/bin/nvcc}"
+export PATH="$CUDA_HOME/bin:$PATH"
 export UV_LINK_MODE=copy
 # Keep uv's cache + build temp off the (quota-limited) home filesystem.
 export UV_CACHE_DIR="${UV_CACHE_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/.uvcache}"

--- a/benchmarks/slurm/soak_fused_scan.sbatch
+++ b/benchmarks/slurm/soak_fused_scan.sbatch
@@ -22,9 +22,19 @@
 set -euo pipefail
 cd "${SLURM_SUBMIT_DIR:-$PWD}"
 
-export PATH="/usr/local/cuda/bin:$PATH"
+# Prefer a known-good CUDA toolkit over the /usr/local/cuda symlink: the gpu7
+# upgrade to nvcc 13.3 (2026-06) broke compilation of torch 2.10's own headers
+# (ATen/core/List_inl.h: "need 'typename' before 'decltype'"); 13.2 builds
+# cleanly. Fall back to the symlink only when no pinned version exists.
+for _cuda_v in 13.2 12.9 12.8 12.6 12.4; do
+  if [ -x "/usr/local/cuda-${_cuda_v}/bin/nvcc" ]; then
+    export CUDA_HOME="/usr/local/cuda-${_cuda_v}"
+    break
+  fi
+done
 export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
-export CUDACXX="${CUDACXX:-/usr/local/cuda/bin/nvcc}"
+export CUDACXX="${CUDACXX:-$CUDA_HOME/bin/nvcc}"
+export PATH="$CUDA_HOME/bin:$PATH"
 export UV_LINK_MODE=copy
 # Keep uv's cache + build temp off the (quota-limited) home filesystem.
 export UV_CACHE_DIR="${UV_CACHE_DIR:-${SLURM_SUBMIT_DIR:-$PWD}/.uvcache}"

--- a/benchmarks/test_hotpath_bench.py
+++ b/benchmarks/test_hotpath_bench.py
@@ -98,7 +98,7 @@ def test_reverb_effect(cuda_sync_benchmark, device):
         pytest.skip("CUDA not available")
 
     x = create_signal_torch(2, 1.0, device)
-    reverb = Reverb(delay=2048, decay=0.5, mix=0.3)
+    reverb = Reverb(room_size=0.5, damping=0.5, mix=0.3, fs=SAMPLE_RATE)
     if device == "cuda":
         reverb = reverb.to("cuda")
 

--- a/examples/ddsp_graphic_eq.py
+++ b/examples/ddsp_graphic_eq.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Differentiable DSP proof-of-concept: a learnable parametric EQ in TorchFX.
+
+This example demonstrates that TorchFX's SOS filter representation is usable in a
+fully differentiable, gradient-trained pipeline. A cascade of RBJ peaking-EQ
+biquads — the same second-order sections the native TorchFX kernels execute — is
+parameterised by learnable per-band ``(center frequency, Q, gain)`` and applied in
+the **frequency domain** (FFT x H), where plain autograd differentiates everything:
+no custom backward pass, no modification of the fast ``@torch.no_grad()`` inference
+kernels.
+
+Task: invert an unknown coloration filter. A synthetic "speaker" response (a few
+fixed resonances + a low shelf) colors a noise signal; the EQ is trained with a
+multi-resolution STFT loss so that ``eq(colored)`` matches the original signal.
+Gradients flow  loss -> STFT -> waveform -> H(e^jw) -> RBJ coefficients ->
+(fc, Q, gain)  end to end.
+
+Run (CPU is fine; CUDA used when available)::
+
+    python examples/ddsp_graphic_eq.py            # train + save figure/audio
+    python examples/ddsp_graphic_eq.py --steps 0  # just plot the untrained EQ
+
+The trained band parameters can be transferred 1:1 onto native TorchFX biquads for
+fast no-grad inference, since both share the RBJ SOS parameterisation.
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+
+import torch
+from torch import Tensor, nn
+
+# --------------------------------------------------------------------------- #
+# Differentiable RBJ peaking-EQ cascade (frequency-domain application).        #
+# --------------------------------------------------------------------------- #
+
+
+def rbj_peaking_sos(fc: Tensor, q: Tensor, gain_db: Tensor, fs: float) -> Tensor:
+    """RBJ-cookbook peaking-EQ section as a differentiable ``[K, 6]`` SOS stack.
+
+    Identical math to ``torchfx.filter.biquad.BiquadPeak`` but in batched torch ops
+    so the coefficients stay on the autograd tape: gradients flow back to ``fc``,
+    ``q`` and ``gain_db``.
+
+    """
+    A = torch.pow(10.0, gain_db / 40.0)
+    w0 = 2.0 * math.pi * fc / fs
+    cos_w0 = torch.cos(w0)
+    alpha = torch.sin(w0) / (2.0 * q)
+
+    b0 = 1.0 + alpha * A
+    b1 = -2.0 * cos_w0
+    b2 = 1.0 - alpha * A
+    a0 = 1.0 + alpha / A
+    a1 = -2.0 * cos_w0
+    a2 = 1.0 - alpha / A
+
+    sos = torch.stack([b0 / a0, b1 / a0, b2 / a0, torch.ones_like(a0), a1 / a0, a2 / a0], dim=-1)
+    return sos
+
+
+def sos_freq_response(sos: Tensor, n_fft: int) -> Tensor:
+    """Complex frequency response of an SOS cascade on the ``rfft`` grid.
+
+    ``H(z) = prod_k (b0 + b1 z^-1 + b2 z^-2) / (1 + a1 z^-1 + a2 z^-2)`` evaluated at
+    ``z = e^{jw}`` for the ``n_fft//2 + 1`` non-negative frequency bins. All ops are
+    complex-differentiable, so this is the autograd path from coefficients to audio.
+
+    """
+    w = torch.linspace(0.0, math.pi, n_fft // 2 + 1, device=sos.device, dtype=sos.dtype)
+    z1 = torch.exp(torch.complex(torch.zeros_like(w), -w))  # z^-1
+    z2 = z1 * z1
+    b = sos[:, 0:1] + sos[:, 1:2] * z1 + sos[:, 2:3] * z2  # [K, F]
+    a = sos[:, 3:4] + sos[:, 4:5] * z1 + sos[:, 5:6] * z2
+    return torch.prod(b / a, dim=0)  # [F]
+
+
+class LearnableParametricEQ(nn.Module):
+    """A cascade of peaking-EQ bands with learnable (fc, Q, gain) per band.
+
+    Raw parameters are unconstrained; sigmoid/exp maps (FLAMO-style) keep the
+    effective values in stable, audible ranges so training cannot push a pole
+    outside the unit circle.
+
+    """
+
+    def __init__(
+        self,
+        n_bands: int = 10,
+        fs: float = 48_000,
+        f_lo: float = 40.0,
+        f_hi: float = 16_000.0,
+        max_gain_db: float = 18.0,
+    ) -> None:
+        super().__init__()
+        self.fs = fs
+        self.f_lo, self.f_hi = f_lo, f_hi
+        self.max_gain_db = max_gain_db
+        # Initialise band centers log-spaced over [f_lo, f_hi]; the sigmoid map
+        # below is centered so raw zeros land back on this grid.
+        grid = torch.linspace(0.0, 1.0, n_bands + 2)[1:-1]
+        self._fc_raw = nn.Parameter(torch.logit(grid))
+        self._q_raw = nn.Parameter(torch.zeros(n_bands))  # exp map: q0 * e^raw
+        self.gain_db_raw = nn.Parameter(torch.zeros(n_bands))
+
+    @property
+    def fc(self) -> Tensor:
+        """Band centers, log-spaced sigmoid map into [f_lo, f_hi]."""
+        t = torch.sigmoid(self._fc_raw)
+        return self.f_lo * (self.f_hi / self.f_lo) ** t
+
+    @property
+    def q(self) -> Tensor:
+        """Band Q, exp map around 1.0, clamped to [0.3, 8]."""
+        return torch.clamp(math.sqrt(2.0) * torch.exp(self._q_raw), 0.3, 8.0)
+
+    @property
+    def gain_db(self) -> Tensor:
+        """Band gain in dB, tanh-bounded to +/- max_gain_db."""
+        return self.max_gain_db * torch.tanh(self.gain_db_raw)
+
+    def sos(self) -> Tensor:
+        """The cascade as a differentiable ``[K, 6]`` SOS stack (TorchFX layout)."""
+        return rbj_peaking_sos(self.fc, self.q, self.gain_db, self.fs)
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Filter ``x`` (``[C, T]``) through the cascade in the frequency domain."""
+        n_fft = 2 ** math.ceil(math.log2(x.shape[-1]))
+        H = sos_freq_response(self.sos().to(torch.float64), n_fft).to(torch.complex64)
+        X = torch.fft.rfft(x, n=n_fft)
+        y = torch.fft.irfft(X * H, n=n_fft)
+        return y[..., : x.shape[-1]]
+
+
+# --------------------------------------------------------------------------- #
+# Multi-resolution STFT loss (the standard DDSP reconstruction objective).     #
+# --------------------------------------------------------------------------- #
+
+
+def multires_stft_loss(x: Tensor, y: Tensor, sizes: tuple[int, ...] = (512, 1024, 2048)) -> Tensor:
+    """Sum of spectral-convergence + log-magnitude L1 over several STFT resolutions."""
+    loss = x.new_zeros(())
+    for n_fft in sizes:
+        win = torch.hann_window(n_fft, device=x.device)
+        X = torch.stft(x, n_fft, n_fft // 4, window=win, return_complex=True).abs()
+        Y = torch.stft(y, n_fft, n_fft // 4, window=win, return_complex=True).abs()
+        loss = loss + torch.norm(X - Y) / (torch.norm(Y) + 1e-8)
+        loss = loss + torch.nn.functional.l1_loss(torch.log(X + 1e-5), torch.log(Y + 1e-5))
+    return loss
+
+
+# --------------------------------------------------------------------------- #
+# The unknown coloration to invert (fixed, non-learnable).                     #
+# --------------------------------------------------------------------------- #
+
+
+def make_coloration(fs: float) -> Tensor:
+    """A synthetic 'speaker' coloration: three resonances + one deep notch."""
+    fc = torch.tensor([120.0, 900.0, 3200.0, 7800.0])
+    q = torch.tensor([1.2, 2.5, 1.8, 3.0])
+    g = torch.tensor([+9.0, -12.0, +7.0, -10.0])
+    return rbj_peaking_sos(fc, q, g, fs)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--steps", type=int, default=400)
+    parser.add_argument("--bands", type=int, default=10)
+    parser.add_argument("--fs", type=int, default=48_000)
+    parser.add_argument("--seconds", type=float, default=2.0)
+    parser.add_argument("--lr", type=float, default=2e-2)
+    parser.add_argument("--out", type=str, default="examples/ddsp_eq_result.png")
+    args = parser.parse_args()
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    torch.manual_seed(0)
+
+    # Training signal: pink-ish noise (white noise shaped by 1/sqrt(f)).
+    T = int(args.fs * args.seconds)
+    n_fft = 2 ** math.ceil(math.log2(T))
+    white = torch.randn(1, T, device=device)
+    freqs = torch.fft.rfftfreq(n_fft, 1 / args.fs, device=device)
+    shape = 1.0 / torch.sqrt(torch.clamp(freqs, min=20.0))
+    x = torch.fft.irfft(torch.fft.rfft(white, n=n_fft) * shape, n=n_fft)[..., :T]
+    x = x / x.abs().max()
+
+    # Color the signal with the unknown response (no grad — it is the plant).
+    color_sos = make_coloration(args.fs).to(device)
+    with torch.no_grad():
+        Hc = sos_freq_response(color_sos.to(torch.float64), n_fft).to(torch.complex64)
+        colored = torch.fft.irfft(torch.fft.rfft(x, n=n_fft) * Hc, n=n_fft)[..., :T]
+
+    # The learnable EQ must invert the coloration: eq(colored) ~= x.
+    eq = LearnableParametricEQ(n_bands=args.bands, fs=args.fs).to(device)
+    opt = torch.optim.Adam(eq.parameters(), lr=args.lr)
+
+    losses: list[float] = []
+    for step in range(args.steps):
+        opt.zero_grad()
+        y = eq(colored)
+        loss = multires_stft_loss(y.squeeze(0), x.squeeze(0))
+        loss.backward()
+        opt.step()
+        losses.append(loss.detach().item())
+        if step % 50 == 0 or step == args.steps - 1:
+            print(f"step {step:4d}  loss {losses[-1]:.4f}")
+
+    # ----- report ----------------------------------------------------------- #
+    with torch.no_grad():
+        H_eq = sos_freq_response(eq.sos().to(torch.float64), n_fft)
+        H_col = sos_freq_response(color_sos.to(torch.float64), n_fft)
+        f = torch.fft.rfftfreq(n_fft, 1 / args.fs)
+        eq_db = 20 * torch.log10(H_eq.abs() + 1e-9).cpu()
+        col_db = 20 * torch.log10(H_col.abs() + 1e-9).cpu()
+        residual_db = eq_db + col_db  # perfect inversion -> 0 dB everywhere
+
+        band = (f > 60) & (f < 12_000)
+        flatness = residual_db[band].abs().mean()
+        print(f"\nresidual |coloration + EQ| over 60 Hz..12 kHz: {flatness:.2f} dB mean abs")
+        print("learned bands (fc Hz / Q / gain dB):")
+        for fc_i, q_i, g_i in zip(eq.fc.cpu(), eq.q.cpu(), eq.gain_db.cpu(), strict=True):
+            print(f"  {fc_i:8.1f}  {q_i:5.2f}  {g_i:+6.2f}")
+
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 3.6))
+        ax1.plot(losses)
+        ax1.set_xlabel("step")
+        ax1.set_ylabel("multi-res STFT loss")
+        ax1.set_title("Training loss")
+        ax2.semilogx(f, col_db, label="coloration (unknown)", lw=1.2)
+        ax2.semilogx(f, eq_db, label="learned EQ", lw=1.2)
+        ax2.semilogx(f, residual_db, label="residual (sum)", lw=1.2, ls="--")
+        ax2.set_xlim(20, args.fs / 2)
+        ax2.set_ylim(-24, 24)
+        ax2.set_xlabel("frequency (Hz)")
+        ax2.set_ylabel("magnitude (dB)")
+        ax2.legend(fontsize=8)
+        ax2.set_title("Learned inverse response")
+        fig.tight_layout()
+        fig.savefig(args.out, dpi=150)
+        print(f"figure saved to {args.out}")
+    except ImportError:
+        print("matplotlib not available; skipping figure")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/torchfx/_csrc/binding.cpp
+++ b/src/torchfx/_csrc/binding.cpp
@@ -30,7 +30,7 @@ torch::Tensor delay_line_forward_cpu(
     double decay,
     double mix);
 
-torch::Tensor compressor_forward_cpu(
+std::tuple<torch::Tensor, torch::Tensor> compressor_forward_cpu(
     const torch::Tensor& x,
     double threshold_db,
     double inv_ratio,
@@ -39,9 +39,10 @@ torch::Tensor compressor_forward_cpu(
     double attack_coeff,
     double release_coeff,
     double rms_coeff,
-    int detector);
+    int detector,
+    const torch::Tensor& state);
 
-torch::Tensor expander_forward_cpu(
+std::tuple<torch::Tensor, torch::Tensor> expander_forward_cpu(
     const torch::Tensor& x,
     double threshold_db,
     double slope,
@@ -50,16 +51,18 @@ torch::Tensor expander_forward_cpu(
     double attack_coeff,
     double release_coeff,
     double rms_coeff,
-    int detector);
+    int detector,
+    const torch::Tensor& state);
 
-torch::Tensor limiter_forward_cpu(
+std::tuple<torch::Tensor, torch::Tensor> limiter_forward_cpu(
     const torch::Tensor& x,
     const torch::Tensor& peak_env,
     double threshold_lin,
     double attack_coeff,
-    double release_coeff);
+    double release_coeff,
+    const torch::Tensor& state);
 
-torch::Tensor reverb_forward_cpu(
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> reverb_forward_cpu(
     const torch::Tensor& x,
     int fs,
     double feedback,
@@ -67,7 +70,10 @@ torch::Tensor reverb_forward_cpu(
     double input_gain,
     double allpass_fb,
     double wet,
-    double dry);
+    double dry,
+    const torch::Tensor& scratch,
+    const torch::Tensor& fstore,
+    const torch::Tensor& idx);
 
 // Dispatch: select CUDA or CPU implementation based on tensor device.
 // `threshold` is the sequential-vs-parallel-scan boundary used by the CUDA path
@@ -132,7 +138,7 @@ torch::Tensor delay_line_forward(
 // Compressor dispatch. `inv_ratio` = 1/ratio (0 for an infinite-ratio limiter);
 // `detector` is 0=peak, 1=rms. Coefficients are precomputed by the Python layer
 // from attack/release/rms times and fs.
-torch::Tensor compressor_forward(
+std::tuple<torch::Tensor, torch::Tensor> compressor_forward(
     const torch::Tensor& x,
     double threshold_db,
     double inv_ratio,
@@ -141,24 +147,26 @@ torch::Tensor compressor_forward(
     double attack_coeff,
     double release_coeff,
     double rms_coeff,
-    int detector) {
+    int detector,
+    const c10::optional<torch::Tensor>& state_opt) {
+  const torch::Tensor state = state_opt.has_value() ? *state_opt : torch::Tensor();
 #ifdef WITH_CUDA
   if (x.is_cuda()) {
     return torchfx::compressor_forward_cuda(x, threshold_db, inv_ratio, knee_db,
                                             makeup_db, attack_coeff, release_coeff,
-                                            rms_coeff, detector);
+                                            rms_coeff, detector, state);
   }
 #else
   TORCH_CHECK(!x.is_cuda(), "CUDA extension not compiled; move tensors to CPU");
 #endif
   return compressor_forward_cpu(x, threshold_db, inv_ratio, knee_db, makeup_db,
-                                attack_coeff, release_coeff, rms_coeff, detector);
+                                attack_coeff, release_coeff, rms_coeff, detector, state);
 }
 
 // Expander / gate dispatch. `slope` = ratio-1 (a large finite value for a gate, so the
 // kernel never does inf arithmetic); `floor_db` is the deepest attenuation; `detector`
 // is 0=peak, 1=rms. Coefficients are precomputed by the Python layer.
-torch::Tensor expander_forward(
+std::tuple<torch::Tensor, torch::Tensor> expander_forward(
     const torch::Tensor& x,
     double threshold_db,
     double slope,
@@ -167,41 +175,46 @@ torch::Tensor expander_forward(
     double attack_coeff,
     double release_coeff,
     double rms_coeff,
-    int detector) {
+    int detector,
+    const c10::optional<torch::Tensor>& state_opt) {
+  const torch::Tensor state = state_opt.has_value() ? *state_opt : torch::Tensor();
 #ifdef WITH_CUDA
   if (x.is_cuda()) {
     return torchfx::expander_forward_cuda(x, threshold_db, slope, knee_db,
                                           floor_db, attack_coeff, release_coeff,
-                                          rms_coeff, detector);
+                                          rms_coeff, detector, state);
   }
 #else
   TORCH_CHECK(!x.is_cuda(), "CUDA extension not compiled; move tensors to CPU");
 #endif
   return expander_forward_cpu(x, threshold_db, slope, knee_db, floor_db,
-                              attack_coeff, release_coeff, rms_coeff, detector);
+                              attack_coeff, release_coeff, rms_coeff, detector, state);
 }
 
 // Look-ahead brick-wall limiter dispatch. `peak_env` is the precomputed look-ahead
 // windowed peak of |x|; `threshold_lin` is the linear ceiling.
-torch::Tensor limiter_forward(
+std::tuple<torch::Tensor, torch::Tensor> limiter_forward(
     const torch::Tensor& x,
     const torch::Tensor& peak_env,
     double threshold_lin,
     double attack_coeff,
-    double release_coeff) {
+    double release_coeff,
+    const c10::optional<torch::Tensor>& state_opt) {
+  const torch::Tensor state = state_opt.has_value() ? *state_opt : torch::Tensor();
 #ifdef WITH_CUDA
   if (x.is_cuda()) {
-    return torchfx::limiter_forward_cuda(x, peak_env, threshold_lin, attack_coeff, release_coeff);
+    return torchfx::limiter_forward_cuda(x, peak_env, threshold_lin, attack_coeff,
+                                         release_coeff, state);
   }
 #else
   TORCH_CHECK(!x.is_cuda(), "CUDA extension not compiled; move tensors to CPU");
 #endif
-  return limiter_forward_cpu(x, peak_env, threshold_lin, attack_coeff, release_coeff);
+  return limiter_forward_cpu(x, peak_env, threshold_lin, attack_coeff, release_coeff, state);
 }
 
 // Freeverb-style reverb dispatch. Comb/all-pass tunings scale with `fs`; `feedback`,
 // `damp`, `wet`, `dry` come from the Python layer's room-size/damping/mix parameters.
-torch::Tensor reverb_forward(
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> reverb_forward(
     const torch::Tensor& x,
     int fs,
     double feedback,
@@ -209,15 +222,23 @@ torch::Tensor reverb_forward(
     double input_gain,
     double allpass_fb,
     double wet,
-    double dry) {
+    double dry,
+    const c10::optional<torch::Tensor>& scratch_opt,
+    const c10::optional<torch::Tensor>& fstore_opt,
+    const c10::optional<torch::Tensor>& idx_opt) {
+  const torch::Tensor scratch = scratch_opt.has_value() ? *scratch_opt : torch::Tensor();
+  const torch::Tensor fstore = fstore_opt.has_value() ? *fstore_opt : torch::Tensor();
+  const torch::Tensor idx = idx_opt.has_value() ? *idx_opt : torch::Tensor();
 #ifdef WITH_CUDA
   if (x.is_cuda()) {
-    return torchfx::reverb_forward_cuda(x, fs, feedback, damp, input_gain, allpass_fb, wet, dry);
+    return torchfx::reverb_forward_cuda(x, fs, feedback, damp, input_gain, allpass_fb,
+                                        wet, dry, scratch, fstore, idx);
   }
 #else
   TORCH_CHECK(!x.is_cuda(), "CUDA extension not compiled; move tensors to CPU");
 #endif
-  return reverb_forward_cpu(x, fs, feedback, damp, input_gain, allpass_fb, wet, dry);
+  return reverb_forward_cpu(x, fs, feedback, damp, input_gain, allpass_fb, wet, dry,
+                            scratch, fstore, idx);
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
@@ -234,21 +255,24 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         py::arg("x"), py::arg("delay_samples"),
         py::arg("decay"), py::arg("mix"));
   m.def("compressor_forward", &compressor_forward,
-        "Compressor forward (CUDA/CPU)",
+        "Compressor forward (CUDA/CPU); returns (y, state)",
         py::arg("x"), py::arg("threshold"), py::arg("inv_ratio"), py::arg("knee"),
         py::arg("makeup_db"), py::arg("attack_coeff"), py::arg("release_coeff"),
-        py::arg("rms_coeff"), py::arg("detector"));
+        py::arg("rms_coeff"), py::arg("detector"), py::arg("state") = py::none());
   m.def("expander_forward", &expander_forward,
-        "Expander / gate forward (CUDA/CPU)",
+        "Expander / gate forward (CUDA/CPU); returns (y, state)",
         py::arg("x"), py::arg("threshold"), py::arg("slope"), py::arg("knee"),
         py::arg("floor_db"), py::arg("attack_coeff"), py::arg("release_coeff"),
-        py::arg("rms_coeff"), py::arg("detector"));
+        py::arg("rms_coeff"), py::arg("detector"), py::arg("state") = py::none());
   m.def("limiter_forward", &limiter_forward,
-        "Look-ahead brick-wall limiter forward (CUDA/CPU)",
+        "Look-ahead brick-wall limiter forward (CUDA/CPU); returns (y, state)",
         py::arg("x"), py::arg("peak_env"), py::arg("threshold_lin"),
-        py::arg("attack_coeff"), py::arg("release_coeff"));
+        py::arg("attack_coeff"), py::arg("release_coeff"),
+        py::arg("state") = py::none());
   m.def("reverb_forward", &reverb_forward,
-        "Freeverb-style reverb forward (CUDA/CPU)",
+        "Freeverb-style reverb forward (CUDA/CPU); returns (y, scratch, fstore, idx)",
         py::arg("x"), py::arg("fs"), py::arg("feedback"), py::arg("damp"),
-        py::arg("input_gain"), py::arg("allpass_fb"), py::arg("wet"), py::arg("dry"));
+        py::arg("input_gain"), py::arg("allpass_fb"), py::arg("wet"), py::arg("dry"),
+        py::arg("scratch") = py::none(), py::arg("fstore") = py::none(),
+        py::arg("idx") = py::none());
 }

--- a/src/torchfx/_csrc/cpu/compressor_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/compressor_cpu.cpp
@@ -4,6 +4,8 @@
 
 // CPU feed-forward compressor with a decoupled peak detector. One channel per
 // OpenMP thread, sequential over time (the ballistics are a nonlinear recurrence).
+// Detector state (y1, yL, ms) is threaded through a [C, 3] tensor so block-wise
+// streaming is state-continuous across chunks.
 // See include/torchfx/compressor_kernel.h for the per-sample math.
 
 #if defined(_MSC_VER)
@@ -16,6 +18,7 @@ template <typename scalar_t>
 static void compressor_loop(
     const scalar_t* TORCHFX_RESTRICT in_ptr,
     scalar_t* TORCHFX_RESTRICT out_ptr,
+    scalar_t* TORCHFX_RESTRICT state_ptr,  // [C, 3] = (y1, yL, ms), in/out
     int64_t C,
     int64_t T,
     scalar_t threshold_db,
@@ -37,7 +40,9 @@ static void compressor_loop(
     const scalar_t* in_c = in_ptr + c * T;
     scalar_t* out_c = out_ptr + c * T;
 
-    scalar_t y1 = 0, yL = 0, ms = 0;
+    scalar_t y1 = state_ptr[c * 3 + 0];
+    scalar_t yL = state_ptr[c * 3 + 1];
+    scalar_t ms = state_ptr[c * 3 + 2];
     for (int64_t n = 0; n < T; ++n) {
       const scalar_t xn = in_c[n];
 
@@ -68,10 +73,13 @@ static void compressor_loop(
       const scalar_t g = std::pow(static_cast<scalar_t>(10), gdb / twenty);
       out_c[n] = g * xn;
     }
+    state_ptr[c * 3 + 0] = y1;
+    state_ptr[c * 3 + 1] = yL;
+    state_ptr[c * 3 + 2] = ms;
   }
 }
 
-torch::Tensor compressor_forward_cpu(
+std::tuple<torch::Tensor, torch::Tensor> compressor_forward_cpu(
     const torch::Tensor& x,
     double threshold_db,
     double inv_ratio,
@@ -80,7 +88,8 @@ torch::Tensor compressor_forward_cpu(
     double attack_coeff,
     double release_coeff,
     double rms_coeff,
-    int detector) {
+    int detector,
+    const torch::Tensor& state) {
 
   TORCH_CHECK(!x.is_cuda(), "compressor_forward_cpu: input must be on CPU");
 
@@ -94,22 +103,33 @@ torch::Tensor compressor_forward_cpu(
   const int64_t T = x_cont.size(1);
   auto output = torch::empty_like(x_cont);
 
+  // Detector state (y1, yL, ms) per channel: fresh zeros when not supplied,
+  // otherwise updated in place for chunk-to-chunk streaming continuity.
+  torch::Tensor st = state;
+  if (!st.defined()) {
+    st = torch::zeros({C, 3}, x_cont.options());
+  } else {
+    TORCH_CHECK(st.size(0) == C && st.size(1) == 3 && st.dtype() == x_cont.dtype(),
+                "compressor_forward_cpu: state must be [C, 3] with the input dtype");
+    st = st.contiguous();
+  }
+
   if (x_cont.dtype() == torch::kFloat32) {
     compressor_loop<float>(
-        x_cont.data_ptr<float>(), output.data_ptr<float>(), C, T,
+        x_cont.data_ptr<float>(), output.data_ptr<float>(), st.data_ptr<float>(), C, T,
         static_cast<float>(threshold_db), static_cast<float>(inv_ratio),
         static_cast<float>(knee_db), static_cast<float>(makeup_db),
         static_cast<float>(attack_coeff), static_cast<float>(release_coeff),
         static_cast<float>(rms_coeff), detector);
   } else {
     compressor_loop<double>(
-        x_cont.data_ptr<double>(), output.data_ptr<double>(), C, T,
+        x_cont.data_ptr<double>(), output.data_ptr<double>(), st.data_ptr<double>(), C, T,
         threshold_db, inv_ratio, knee_db, makeup_db,
         attack_coeff, release_coeff, rms_coeff, detector);
   }
 
   if (orig_dim == 1) {
-    return output.squeeze(0);
+    return {output.squeeze(0), st};
   }
-  return output;
+  return {output, st};
 }

--- a/src/torchfx/_csrc/cpu/compressor_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/compressor_cpu.cpp
@@ -129,7 +129,7 @@ std::tuple<torch::Tensor, torch::Tensor> compressor_forward_cpu(
   }
 
   if (orig_dim == 1) {
-    return {output.squeeze(0), st};
+    return std::make_tuple(output.squeeze(0), st);
   }
-  return {output, st};
+  return std::make_tuple(output, st);
 }

--- a/src/torchfx/_csrc/cpu/expander_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/expander_cpu.cpp
@@ -16,6 +16,7 @@ template <typename scalar_t>
 static void expander_loop(
     const scalar_t* TORCHFX_RESTRICT in_ptr,
     scalar_t* TORCHFX_RESTRICT out_ptr,
+    scalar_t* TORCHFX_RESTRICT state_ptr,  // [C, 3] = (y1, yL, ms), in/out
     int64_t C,
     int64_t T,
     scalar_t threshold_db,
@@ -37,7 +38,9 @@ static void expander_loop(
     const scalar_t* in_c = in_ptr + c * T;
     scalar_t* out_c = out_ptr + c * T;
 
-    scalar_t y1 = 0, yL = 0, ms = 0;
+    scalar_t y1 = state_ptr[c * 3 + 0];
+    scalar_t yL = state_ptr[c * 3 + 1];
+    scalar_t ms = state_ptr[c * 3 + 2];
     for (int64_t n = 0; n < T; ++n) {
       const scalar_t xn = in_c[n];
 
@@ -68,10 +71,13 @@ static void expander_loop(
       const scalar_t g = std::pow(static_cast<scalar_t>(10), gdb / twenty);
       out_c[n] = g * xn;
     }
+    state_ptr[c * 3 + 0] = y1;
+    state_ptr[c * 3 + 1] = yL;
+    state_ptr[c * 3 + 2] = ms;
   }
 }
 
-torch::Tensor expander_forward_cpu(
+std::tuple<torch::Tensor, torch::Tensor> expander_forward_cpu(
     const torch::Tensor& x,
     double threshold_db,
     double slope,
@@ -80,7 +86,8 @@ torch::Tensor expander_forward_cpu(
     double attack_coeff,
     double release_coeff,
     double rms_coeff,
-    int detector) {
+    int detector,
+    const torch::Tensor& state) {
 
   TORCH_CHECK(!x.is_cuda(), "expander_forward_cpu: input must be on CPU");
 
@@ -94,22 +101,33 @@ torch::Tensor expander_forward_cpu(
   const int64_t T = x_cont.size(1);
   auto output = torch::empty_like(x_cont);
 
+  // Detector state (y1, yL, ms) per channel: fresh zeros when not supplied,
+  // otherwise updated in place for chunk-to-chunk streaming continuity.
+  torch::Tensor st = state;
+  if (!st.defined()) {
+    st = torch::zeros({C, 3}, x_cont.options());
+  } else {
+    TORCH_CHECK(st.size(0) == C && st.size(1) == 3 && st.dtype() == x_cont.dtype(),
+                "expander_forward_cpu: state must be [C, 3] with the input dtype");
+    st = st.contiguous();
+  }
+
   if (x_cont.dtype() == torch::kFloat32) {
     expander_loop<float>(
-        x_cont.data_ptr<float>(), output.data_ptr<float>(), C, T,
+        x_cont.data_ptr<float>(), output.data_ptr<float>(), st.data_ptr<float>(), C, T,
         static_cast<float>(threshold_db), static_cast<float>(slope),
         static_cast<float>(knee_db), static_cast<float>(floor_db),
         static_cast<float>(attack_coeff), static_cast<float>(release_coeff),
         static_cast<float>(rms_coeff), detector);
   } else {
     expander_loop<double>(
-        x_cont.data_ptr<double>(), output.data_ptr<double>(), C, T,
+        x_cont.data_ptr<double>(), output.data_ptr<double>(), st.data_ptr<double>(), C, T,
         threshold_db, slope, knee_db, floor_db,
         attack_coeff, release_coeff, rms_coeff, detector);
   }
 
   if (orig_dim == 1) {
-    return output.squeeze(0);
+    return {output.squeeze(0), st};
   }
-  return output;
+  return {output, st};
 }

--- a/src/torchfx/_csrc/cpu/expander_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/expander_cpu.cpp
@@ -127,7 +127,7 @@ std::tuple<torch::Tensor, torch::Tensor> expander_forward_cpu(
   }
 
   if (orig_dim == 1) {
-    return {output.squeeze(0), st};
+    return std::make_tuple(output.squeeze(0), st);
   }
-  return {output, st};
+  return std::make_tuple(output, st);
 }

--- a/src/torchfx/_csrc/cpu/limiter_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/limiter_cpu.cpp
@@ -95,7 +95,7 @@ std::tuple<torch::Tensor, torch::Tensor> limiter_forward_cpu(
   }
 
   if (orig_dim == 1) {
-    return {output.squeeze(0), st};
+    return std::make_tuple(output.squeeze(0), st);
   }
-  return {output, st};
+  return std::make_tuple(output, st);
 }

--- a/src/torchfx/_csrc/cpu/limiter_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/limiter_cpu.cpp
@@ -17,6 +17,7 @@ static void limiter_loop(
     const scalar_t* TORCHFX_RESTRICT in_ptr,
     const scalar_t* TORCHFX_RESTRICT peak_ptr,
     scalar_t* TORCHFX_RESTRICT out_ptr,
+    scalar_t* TORCHFX_RESTRICT state_ptr,  // [C, 1] = (g), in/out
     int64_t C,
     int64_t T,
     scalar_t threshold_lin,
@@ -32,7 +33,7 @@ static void limiter_loop(
     const scalar_t* peak_c = peak_ptr + c * T;
     scalar_t* out_c = out_ptr + c * T;
 
-    scalar_t g = one;
+    scalar_t g = state_ptr[c];
     for (int64_t n = 0; n < T; ++n) {
       const scalar_t gr = std::min(one, threshold_lin / std::max(peak_c[n], eps));
       if (gr < g) {
@@ -44,15 +45,17 @@ static void limiter_loop(
       const scalar_t g_out = std::min(g, clamp);
       out_c[n] = g_out * in_c[n];
     }
+    state_ptr[c] = g;
   }
 }
 
-torch::Tensor limiter_forward_cpu(
+std::tuple<torch::Tensor, torch::Tensor> limiter_forward_cpu(
     const torch::Tensor& x,
     const torch::Tensor& peak_env,
     double threshold_lin,
     double attack_coeff,
-    double release_coeff) {
+    double release_coeff,
+    const torch::Tensor& state) {
 
   TORCH_CHECK(!x.is_cuda(), "limiter_forward_cpu: input must be on CPU");
   TORCH_CHECK(x.sizes() == peak_env.sizes(), "limiter_forward_cpu: x and peak_env must match");
@@ -69,19 +72,30 @@ torch::Tensor limiter_forward_cpu(
   const int64_t T = x_cont.size(1);
   auto output = torch::empty_like(x_cont);
 
+  // Gain state per channel: fresh unity gain when not supplied, otherwise
+  // updated in place for chunk-to-chunk streaming continuity.
+  torch::Tensor st = state;
+  if (!st.defined()) {
+    st = torch::ones({C, 1}, x_cont.options());
+  } else {
+    TORCH_CHECK(st.size(0) == C && st.size(1) == 1 && st.dtype() == x_cont.dtype(),
+                "limiter_forward_cpu: state must be [C, 1] with the input dtype");
+    st = st.contiguous();
+  }
+
   if (x_cont.dtype() == torch::kFloat32) {
     limiter_loop<float>(
         x_cont.data_ptr<float>(), peak_cont.data_ptr<float>(), output.data_ptr<float>(),
-        C, T, static_cast<float>(threshold_lin), static_cast<float>(attack_coeff),
-        static_cast<float>(release_coeff));
+        st.data_ptr<float>(), C, T, static_cast<float>(threshold_lin),
+        static_cast<float>(attack_coeff), static_cast<float>(release_coeff));
   } else {
     limiter_loop<double>(
         x_cont.data_ptr<double>(), peak_cont.data_ptr<double>(), output.data_ptr<double>(),
-        C, T, threshold_lin, attack_coeff, release_coeff);
+        st.data_ptr<double>(), C, T, threshold_lin, attack_coeff, release_coeff);
   }
 
   if (orig_dim == 1) {
-    return output.squeeze(0);
+    return {output.squeeze(0), st};
   }
-  return output;
+  return {output, st};
 }

--- a/src/torchfx/_csrc/cpu/reverb_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/reverb_cpu.cpp
@@ -182,7 +182,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> reverb_fo
   }
 
   if (orig_dim == 1) {
-    return {output.squeeze(0), scratch, fstore, idx};
+    return std::make_tuple(output.squeeze(0), scratch, fstore, idx);
   }
-  return {output, scratch, fstore, idx};
+  return std::make_tuple(output, scratch, fstore, idx);
 }

--- a/src/torchfx/_csrc/cpu/reverb_cpu.cpp
+++ b/src/torchfx/_csrc/cpu/reverb_cpu.cpp
@@ -40,6 +40,8 @@ void reverb_loop(
     const scalar_t* TORCHFX_RESTRICT in_ptr,
     scalar_t* TORCHFX_RESTRICT out_ptr,
     scalar_t* TORCHFX_RESTRICT scratch,
+    scalar_t* TORCHFX_RESTRICT fstore_ptr,  // [C, kReverbNumCombs] damping state, in/out
+    int* TORCHFX_RESTRICT idx_ptr,          // [C, combs+allpasses] ring positions, in/out
     int64_t C,
     int64_t T,
     const int* comb_len,
@@ -66,11 +68,14 @@ void reverb_loop(
     scalar_t fstore[torchfx::kReverbNumCombs];
     int cidx[torchfx::kReverbNumCombs];
     int aidx[torchfx::kReverbNumAllpass];
+    scalar_t* fs_c = fstore_ptr + c * torchfx::kReverbNumCombs;
+    int* idx_c = idx_ptr + c * (torchfx::kReverbNumCombs + torchfx::kReverbNumAllpass);
     for (int i = 0; i < torchfx::kReverbNumCombs; ++i) {
-      fstore[i] = 0;
-      cidx[i] = 0;
+      fstore[i] = fs_c[i];
+      cidx[i] = idx_c[i];
     }
-    for (int j = 0; j < torchfx::kReverbNumAllpass; ++j) aidx[j] = 0;
+    for (int j = 0; j < torchfx::kReverbNumAllpass; ++j)
+      aidx[j] = idx_c[torchfx::kReverbNumCombs + j];
 
     for (int64_t n = 0; n < T; ++n) {
       const scalar_t xn = in_c[n];
@@ -94,12 +99,19 @@ void reverb_loop(
       }
       out_c[n] = xn * dry + acc * wet;
     }
+
+    for (int i = 0; i < torchfx::kReverbNumCombs; ++i) {
+      fs_c[i] = fstore[i];
+      idx_c[i] = cidx[i];
+    }
+    for (int j = 0; j < torchfx::kReverbNumAllpass; ++j)
+      idx_c[torchfx::kReverbNumCombs + j] = aidx[j];
   }
 }
 
 }  // namespace
 
-torch::Tensor reverb_forward_cpu(
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> reverb_forward_cpu(
     const torch::Tensor& x,
     int fs,
     double feedback,
@@ -107,7 +119,10 @@ torch::Tensor reverb_forward_cpu(
     double input_gain,
     double allpass_fb,
     double wet,
-    double dry) {
+    double dry,
+    const torch::Tensor& scratch_in,
+    const torch::Tensor& fstore_in,
+    const torch::Tensor& idx_in) {
 
   TORCH_CHECK(!x.is_cuda(), "reverb_forward_cpu: input must be on CPU");
 
@@ -125,23 +140,49 @@ torch::Tensor reverb_forward_cpu(
   reverb_dims(fs, comb_len, comb_off, ap_len, ap_off, comb_total, total);
 
   auto output = torch::empty_like(x_cont);
-  auto scratch = torch::zeros({C, static_cast<int64_t>(total)}, x_cont.options());
+  const int n_idx = torchfx::kReverbNumCombs + torchfx::kReverbNumAllpass;
+
+  // Delay-line state: fresh zeros when not supplied, otherwise updated in place
+  // for chunk-to-chunk streaming continuity. All three must be passed together.
+  torch::Tensor scratch = scratch_in, fstore = fstore_in, idx = idx_in;
+  if (!scratch.defined()) {
+    scratch = torch::zeros({C, static_cast<int64_t>(total)}, x_cont.options());
+    fstore = torch::zeros({C, torchfx::kReverbNumCombs}, x_cont.options());
+    idx = torch::zeros({C, n_idx}, x_cont.options().dtype(torch::kInt32));
+  } else {
+    TORCH_CHECK(fstore.defined() && idx.defined(),
+                "reverb_forward_cpu: scratch/fstore/idx must be passed together");
+    TORCH_CHECK(scratch.size(0) == C && scratch.size(1) == total &&
+                    scratch.dtype() == x_cont.dtype(),
+                "reverb_forward_cpu: scratch must be [C, ", total, "] with the input dtype "
+                "(state from a different fs or channel count is not reusable)");
+    TORCH_CHECK(fstore.size(0) == C && fstore.size(1) == torchfx::kReverbNumCombs &&
+                    fstore.dtype() == x_cont.dtype(),
+                "reverb_forward_cpu: fstore must be [C, ", torchfx::kReverbNumCombs, "]");
+    TORCH_CHECK(idx.size(0) == C && idx.size(1) == n_idx && idx.dtype() == torch::kInt32,
+                "reverb_forward_cpu: idx must be int32 [C, ", n_idx, "]");
+    scratch = scratch.contiguous();
+    fstore = fstore.contiguous();
+    idx = idx.contiguous();
+  }
 
   if (x_cont.dtype() == torch::kFloat32) {
     reverb_loop<float>(
         x_cont.data_ptr<float>(), output.data_ptr<float>(), scratch.data_ptr<float>(),
+        fstore.data_ptr<float>(), idx.data_ptr<int>(),
         C, T, comb_len, comb_off, ap_len, ap_off, comb_total, total,
         static_cast<float>(feedback), static_cast<float>(damp), static_cast<float>(input_gain),
         static_cast<float>(allpass_fb), static_cast<float>(wet), static_cast<float>(dry));
   } else {
     reverb_loop<double>(
         x_cont.data_ptr<double>(), output.data_ptr<double>(), scratch.data_ptr<double>(),
+        fstore.data_ptr<double>(), idx.data_ptr<int>(),
         C, T, comb_len, comb_off, ap_len, ap_off, comb_total, total,
         feedback, damp, input_gain, allpass_fb, wet, dry);
   }
 
   if (orig_dim == 1) {
-    return output.squeeze(0);
+    return {output.squeeze(0), scratch, fstore, idx};
   }
-  return output;
+  return {output, scratch, fstore, idx};
 }

--- a/src/torchfx/_csrc/cuda/biquad_forward.cu
+++ b/src/torchfx/_csrc/cuda/biquad_forward.cu
@@ -98,6 +98,10 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> sos_forward_cuda(
   auto i32 = opts.dtype(torch::kInt32);
   torch::Tensor f, block_agg, status, aggregate, prefix, tile_counter;
   if (use_fused) {
+    // The status word packs (epoch << 2) | state into a signed 32-bit int, where
+    // epoch is the section index — the tag wraps for K >= 2^29 sections.
+    TORCH_CHECK(K < (int64_t{1} << 29),
+                "fused scan: cascade depth ", K, " exceeds the epoch-tag range (2^29)");
     status = torch::zeros({C * num_blocks}, i32);
     aggregate = torch::empty({C * num_blocks * 6}, opts);
     prefix = torch::empty({C * num_blocks * 6}, opts);

--- a/src/torchfx/_csrc/cuda/compressor_forward.cu
+++ b/src/torchfx/_csrc/cuda/compressor_forward.cu
@@ -129,9 +129,9 @@ std::tuple<torch::Tensor, torch::Tensor> compressor_forward_cuda(
   });
 
   if (x.dim() == 1) {
-    return {output.squeeze(0), st};
+    return std::make_tuple(output.squeeze(0), st);
   }
-  return {output, st};
+  return std::make_tuple(output, st);
 }
 
 }  // namespace torchfx

--- a/src/torchfx/_csrc/cuda/compressor_forward.cu
+++ b/src/torchfx/_csrc/cuda/compressor_forward.cu
@@ -15,6 +15,7 @@ template <typename scalar_t>
 __global__ void compressor_kernel(
     const scalar_t* __restrict__ input,
     scalar_t* __restrict__ output,
+    scalar_t* __restrict__ state,  // [C, 3] = (y1, yL, ms), in/out
     scalar_t threshold_db,
     scalar_t inv_ratio,
     scalar_t knee_db,
@@ -37,7 +38,9 @@ __global__ void compressor_kernel(
   const scalar_t two = static_cast<scalar_t>(2);
   const scalar_t twenty = static_cast<scalar_t>(20);
 
-  scalar_t y1 = 0, yL = 0, ms = 0;
+  scalar_t y1 = state[channel * 3 + 0];
+  scalar_t yL = state[channel * 3 + 1];
+  scalar_t ms = state[channel * 3 + 2];
   for (int n = 0; n < T; ++n) {
     const scalar_t xn = in_c[n];
 
@@ -68,9 +71,12 @@ __global__ void compressor_kernel(
     const scalar_t g = pow(static_cast<scalar_t>(10), gdb / twenty);
     out_c[n] = g * xn;
   }
+  state[channel * 3 + 0] = y1;
+  state[channel * 3 + 1] = yL;
+  state[channel * 3 + 2] = ms;
 }
 
-torch::Tensor compressor_forward_cuda(
+std::tuple<torch::Tensor, torch::Tensor> compressor_forward_cuda(
     const torch::Tensor& x,
     double threshold_db,
     double inv_ratio,
@@ -79,7 +85,8 @@ torch::Tensor compressor_forward_cuda(
     double attack_coeff,
     double release_coeff,
     double rms_coeff,
-    int detector) {
+    int detector,
+    const torch::Tensor& state) {
 
   TORCH_CHECK(x.is_cuda(), "compressor_forward_cuda: input must be on CUDA");
 
@@ -96,13 +103,24 @@ torch::Tensor compressor_forward_cuda(
 
   auto output = torch::empty_like(x_cont);
 
+  // Detector state (y1, yL, ms) per channel: fresh zeros when not supplied,
+  // otherwise updated in place for chunk-to-chunk streaming continuity.
+  torch::Tensor st = state;
+  if (!st.defined()) {
+    st = torch::zeros({C, 3}, x_cont.options());
+  } else {
+    TORCH_CHECK(st.size(0) == C && st.size(1) == 3 && st.dtype() == x_cont.dtype() && st.is_cuda(),
+                "compressor_forward_cuda: state must be CUDA [C, 3] with the input dtype");
+    st = st.contiguous();
+  }
+
   const int threads = 128;
   const int blocks = (static_cast<int>(C) + threads - 1) / threads;
   const auto stream = c10::cuda::getCurrentCUDAStream();
 
   AT_DISPATCH_FLOATING_TYPES(x_cont.scalar_type(), "compressor_forward_cuda", [&] {
     compressor_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
-        x_cont.data_ptr<scalar_t>(), output.data_ptr<scalar_t>(),
+        x_cont.data_ptr<scalar_t>(), output.data_ptr<scalar_t>(), st.data_ptr<scalar_t>(),
         static_cast<scalar_t>(threshold_db), static_cast<scalar_t>(inv_ratio),
         static_cast<scalar_t>(knee_db), static_cast<scalar_t>(makeup_db),
         static_cast<scalar_t>(attack_coeff), static_cast<scalar_t>(release_coeff),
@@ -111,9 +129,9 @@ torch::Tensor compressor_forward_cuda(
   });
 
   if (x.dim() == 1) {
-    return output.squeeze(0);
+    return {output.squeeze(0), st};
   }
-  return output;
+  return {output, st};
 }
 
 }  // namespace torchfx

--- a/src/torchfx/_csrc/cuda/delay_forward.cu
+++ b/src/torchfx/_csrc/cuda/delay_forward.cu
@@ -92,11 +92,17 @@ torch::Tensor delay_line_forward_cuda(
     return x;
   }
 
+  // The kernels index with 32-bit ints (channel * T + n).
+  TORCH_CHECK(C * T <= std::numeric_limits<int>::max(),
+              "delay_line_forward_cuda: signal too large for 32-bit indexing (C*T = ",
+              C * T, ")");
+  const int T_i = static_cast<int>(T);
+
   auto output = torch::empty_like(x_cont);
 
   const int threads = 256;
-  const int blocks_t = (T + threads - 1) / threads;
-  dim3 grid(blocks_t, C);
+  const int blocks_t = (T_i + threads - 1) / threads;
+  dim3 grid(blocks_t, static_cast<unsigned int>(C));
 
   // Launch on the current stream (not the default stream) for graph-capture safety.
   const auto stream = c10::cuda::getCurrentCUDAStream();
@@ -108,7 +114,7 @@ torch::Tensor delay_line_forward_cuda(
         delay_samples,
         static_cast<float>(decay),
         static_cast<float>(mix),
-        T);
+        T_i);
   } else {
     delay_line_kernel_f64<<<grid, threads, 0, stream>>>(
         x_cont.data_ptr<double>(),
@@ -116,7 +122,7 @@ torch::Tensor delay_line_forward_cuda(
         delay_samples,
         decay,
         mix,
-        T);
+        T_i);
   }
 
   // Restore original shape

--- a/src/torchfx/_csrc/cuda/delay_forward.cu
+++ b/src/torchfx/_csrc/cuda/delay_forward.cu
@@ -1,6 +1,7 @@
 #include <torch/torch.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include <limits>
 #include <c10/cuda/CUDAStream.h>
 #include "torchfx/delay_kernel.h"
 

--- a/src/torchfx/_csrc/cuda/expander_forward.cu
+++ b/src/torchfx/_csrc/cuda/expander_forward.cu
@@ -130,9 +130,9 @@ std::tuple<torch::Tensor, torch::Tensor> expander_forward_cuda(
   });
 
   if (x.dim() == 1) {
-    return {output.squeeze(0), st};
+    return std::make_tuple(output.squeeze(0), st);
   }
-  return {output, st};
+  return std::make_tuple(output, st);
 }
 
 }  // namespace torchfx

--- a/src/torchfx/_csrc/cuda/expander_forward.cu
+++ b/src/torchfx/_csrc/cuda/expander_forward.cu
@@ -16,6 +16,7 @@ template <typename scalar_t>
 __global__ void expander_kernel(
     const scalar_t* __restrict__ input,
     scalar_t* __restrict__ output,
+    scalar_t* __restrict__ state,  // [C, 3] = (y1, yL, ms), in/out
     scalar_t threshold_db,
     scalar_t slope,
     scalar_t knee_db,
@@ -38,7 +39,9 @@ __global__ void expander_kernel(
   const scalar_t two = static_cast<scalar_t>(2);
   const scalar_t twenty = static_cast<scalar_t>(20);
 
-  scalar_t y1 = 0, yL = 0, ms = 0;
+  scalar_t y1 = state[channel * 3 + 0];
+  scalar_t yL = state[channel * 3 + 1];
+  scalar_t ms = state[channel * 3 + 2];
   for (int n = 0; n < T; ++n) {
     const scalar_t xn = in_c[n];
 
@@ -69,9 +72,12 @@ __global__ void expander_kernel(
     const scalar_t g = pow(static_cast<scalar_t>(10), gdb / twenty);
     out_c[n] = g * xn;
   }
+  state[channel * 3 + 0] = y1;
+  state[channel * 3 + 1] = yL;
+  state[channel * 3 + 2] = ms;
 }
 
-torch::Tensor expander_forward_cuda(
+std::tuple<torch::Tensor, torch::Tensor> expander_forward_cuda(
     const torch::Tensor& x,
     double threshold_db,
     double slope,
@@ -80,7 +86,8 @@ torch::Tensor expander_forward_cuda(
     double attack_coeff,
     double release_coeff,
     double rms_coeff,
-    int detector) {
+    int detector,
+    const torch::Tensor& state) {
 
   TORCH_CHECK(x.is_cuda(), "expander_forward_cuda: input must be on CUDA");
 
@@ -97,13 +104,24 @@ torch::Tensor expander_forward_cuda(
 
   auto output = torch::empty_like(x_cont);
 
+  // Detector state (y1, yL, ms) per channel: fresh zeros when not supplied,
+  // otherwise updated in place for chunk-to-chunk streaming continuity.
+  torch::Tensor st = state;
+  if (!st.defined()) {
+    st = torch::zeros({C, 3}, x_cont.options());
+  } else {
+    TORCH_CHECK(st.size(0) == C && st.size(1) == 3 && st.dtype() == x_cont.dtype() && st.is_cuda(),
+                "expander_forward_cuda: state must be CUDA [C, 3] with the input dtype");
+    st = st.contiguous();
+  }
+
   const int threads = 128;
   const int blocks = (static_cast<int>(C) + threads - 1) / threads;
   const auto stream = c10::cuda::getCurrentCUDAStream();
 
   AT_DISPATCH_FLOATING_TYPES(x_cont.scalar_type(), "expander_forward_cuda", [&] {
     expander_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
-        x_cont.data_ptr<scalar_t>(), output.data_ptr<scalar_t>(),
+        x_cont.data_ptr<scalar_t>(), output.data_ptr<scalar_t>(), st.data_ptr<scalar_t>(),
         static_cast<scalar_t>(threshold_db), static_cast<scalar_t>(slope),
         static_cast<scalar_t>(knee_db), static_cast<scalar_t>(floor_db),
         static_cast<scalar_t>(attack_coeff), static_cast<scalar_t>(release_coeff),
@@ -112,9 +130,9 @@ torch::Tensor expander_forward_cuda(
   });
 
   if (x.dim() == 1) {
-    return output.squeeze(0);
+    return {output.squeeze(0), st};
   }
-  return output;
+  return {output, st};
 }
 
 }  // namespace torchfx

--- a/src/torchfx/_csrc/cuda/limiter_forward.cu
+++ b/src/torchfx/_csrc/cuda/limiter_forward.cu
@@ -15,6 +15,7 @@ __global__ void limiter_kernel(
     const scalar_t* __restrict__ input,
     const scalar_t* __restrict__ peak_env,
     scalar_t* __restrict__ output,
+    scalar_t* __restrict__ state,  // [C, 1] = (g), in/out
     scalar_t threshold_lin,
     scalar_t attack_coeff,
     scalar_t release_coeff,
@@ -31,7 +32,7 @@ __global__ void limiter_kernel(
   const scalar_t eps = static_cast<scalar_t>(1e-12);
   const scalar_t one = static_cast<scalar_t>(1);
 
-  scalar_t g = one;
+  scalar_t g = state[channel];
   for (int n = 0; n < T; ++n) {
     const scalar_t gr = fmin(one, threshold_lin / fmax(peak_c[n], eps));
     if (gr < g) {
@@ -43,14 +44,16 @@ __global__ void limiter_kernel(
     const scalar_t g_out = fmin(g, clamp);
     out_c[n] = g_out * in_c[n];
   }
+  state[channel] = g;
 }
 
-torch::Tensor limiter_forward_cuda(
+std::tuple<torch::Tensor, torch::Tensor> limiter_forward_cuda(
     const torch::Tensor& x,
     const torch::Tensor& peak_env,
     double threshold_lin,
     double attack_coeff,
-    double release_coeff) {
+    double release_coeff,
+    const torch::Tensor& state) {
 
   TORCH_CHECK(x.is_cuda(), "limiter_forward_cuda: input must be on CUDA");
   TORCH_CHECK(x.sizes() == peak_env.sizes(), "limiter_forward_cuda: x and peak_env must match");
@@ -70,6 +73,17 @@ torch::Tensor limiter_forward_cuda(
 
   auto output = torch::empty_like(x_cont);
 
+  // Gain state per channel: fresh unity gain when not supplied, otherwise
+  // updated in place for chunk-to-chunk streaming continuity.
+  torch::Tensor st = state;
+  if (!st.defined()) {
+    st = torch::ones({C, 1}, x_cont.options());
+  } else {
+    TORCH_CHECK(st.size(0) == C && st.size(1) == 1 && st.dtype() == x_cont.dtype() && st.is_cuda(),
+                "limiter_forward_cuda: state must be CUDA [C, 1] with the input dtype");
+    st = st.contiguous();
+  }
+
   const int threads = 128;
   const int blocks = (static_cast<int>(C) + threads - 1) / threads;
   const auto stream = c10::cuda::getCurrentCUDAStream();
@@ -77,14 +91,15 @@ torch::Tensor limiter_forward_cuda(
   AT_DISPATCH_FLOATING_TYPES(x_cont.scalar_type(), "limiter_forward_cuda", [&] {
     limiter_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
         x_cont.data_ptr<scalar_t>(), peak_cont.data_ptr<scalar_t>(), output.data_ptr<scalar_t>(),
+        st.data_ptr<scalar_t>(),
         static_cast<scalar_t>(threshold_lin), static_cast<scalar_t>(attack_coeff),
         static_cast<scalar_t>(release_coeff), static_cast<int>(C), static_cast<int>(T));
   });
 
   if (x.dim() == 1) {
-    return output.squeeze(0);
+    return {output.squeeze(0), st};
   }
-  return output;
+  return {output, st};
 }
 
 }  // namespace torchfx

--- a/src/torchfx/_csrc/cuda/limiter_forward.cu
+++ b/src/torchfx/_csrc/cuda/limiter_forward.cu
@@ -97,9 +97,9 @@ std::tuple<torch::Tensor, torch::Tensor> limiter_forward_cuda(
   });
 
   if (x.dim() == 1) {
-    return {output.squeeze(0), st};
+    return std::make_tuple(output.squeeze(0), st);
   }
-  return {output, st};
+  return std::make_tuple(output, st);
 }
 
 }  // namespace torchfx

--- a/src/torchfx/_csrc/cuda/reverb_forward.cu
+++ b/src/torchfx/_csrc/cuda/reverb_forward.cu
@@ -180,9 +180,9 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> reverb_fo
   });
 
   if (x.dim() == 1) {
-    return {output.squeeze(0), scratch, fstore, idx};
+    return std::make_tuple(output.squeeze(0), scratch, fstore, idx);
   }
-  return {output, scratch, fstore, idx};
+  return std::make_tuple(output, scratch, fstore, idx);
 }
 
 }  // namespace torchfx

--- a/src/torchfx/_csrc/cuda/reverb_forward.cu
+++ b/src/torchfx/_csrc/cuda/reverb_forward.cu
@@ -26,6 +26,8 @@ __global__ void reverb_kernel(
     const scalar_t* __restrict__ input,
     scalar_t* __restrict__ output,
     scalar_t* __restrict__ scratch,
+    scalar_t* __restrict__ fstore_g,  // [C, kReverbNumCombs] damping state, in/out
+    int* __restrict__ idx_g,          // [C, combs+allpasses] ring positions, in/out
     int C,
     int T,
     ReverbDims dims,
@@ -47,13 +49,15 @@ __global__ void reverb_kernel(
   scalar_t fstore[kReverbNumCombs];
   int cidx[kReverbNumCombs];
   int aidx[kReverbNumAllpass];
+  scalar_t* fs_c = fstore_g + static_cast<int64_t>(c) * kReverbNumCombs;
+  int* idx_c = idx_g + static_cast<int64_t>(c) * (kReverbNumCombs + kReverbNumAllpass);
 #pragma unroll
   for (int i = 0; i < kReverbNumCombs; ++i) {
-    fstore[i] = 0;
-    cidx[i] = 0;
+    fstore[i] = fs_c[i];
+    cidx[i] = idx_c[i];
   }
 #pragma unroll
-  for (int j = 0; j < kReverbNumAllpass; ++j) aidx[j] = 0;
+  for (int j = 0; j < kReverbNumAllpass; ++j) aidx[j] = idx_c[kReverbNumCombs + j];
 
   for (int n = 0; n < T; ++n) {
     const scalar_t xn = in_c[n];
@@ -79,9 +83,17 @@ __global__ void reverb_kernel(
     }
     out_c[n] = xn * dry + acc * wet;
   }
+
+#pragma unroll
+  for (int i = 0; i < kReverbNumCombs; ++i) {
+    fs_c[i] = fstore[i];
+    idx_c[i] = cidx[i];
+  }
+#pragma unroll
+  for (int j = 0; j < kReverbNumAllpass; ++j) idx_c[kReverbNumCombs + j] = aidx[j];
 }
 
-torch::Tensor reverb_forward_cuda(
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> reverb_forward_cuda(
     const torch::Tensor& x,
     int fs,
     double feedback,
@@ -89,7 +101,10 @@ torch::Tensor reverb_forward_cuda(
     double input_gain,
     double allpass_fb,
     double wet,
-    double dry) {
+    double dry,
+    const torch::Tensor& scratch_in,
+    const torch::Tensor& fstore_in,
+    const torch::Tensor& idx_in) {
 
   TORCH_CHECK(x.is_cuda(), "reverb_forward_cuda: input must be on CUDA");
 
@@ -124,7 +139,32 @@ torch::Tensor reverb_forward_cuda(
   dims.total = dims.comb_total + ap_total;
 
   auto output = torch::empty_like(x_cont);
-  auto scratch = torch::zeros({C, static_cast<int64_t>(dims.total)}, x_cont.options());
+  const int n_idx = kReverbNumCombs + kReverbNumAllpass;
+
+  // Delay-line state: fresh zeros when not supplied, otherwise updated in place
+  // for chunk-to-chunk streaming continuity. All three must be passed together.
+  torch::Tensor scratch = scratch_in, fstore = fstore_in, idx = idx_in;
+  if (!scratch.defined()) {
+    scratch = torch::zeros({C, static_cast<int64_t>(dims.total)}, x_cont.options());
+    fstore = torch::zeros({C, kReverbNumCombs}, x_cont.options());
+    idx = torch::zeros({C, n_idx}, x_cont.options().dtype(torch::kInt32));
+  } else {
+    TORCH_CHECK(fstore.defined() && idx.defined(),
+                "reverb_forward_cuda: scratch/fstore/idx must be passed together");
+    TORCH_CHECK(scratch.size(0) == C && scratch.size(1) == dims.total &&
+                    scratch.dtype() == x_cont.dtype() && scratch.is_cuda(),
+                "reverb_forward_cuda: scratch must be CUDA [C, ", dims.total,
+                "] with the input dtype");
+    TORCH_CHECK(fstore.size(0) == C && fstore.size(1) == kReverbNumCombs &&
+                    fstore.dtype() == x_cont.dtype() && fstore.is_cuda(),
+                "reverb_forward_cuda: fstore must be CUDA [C, ", kReverbNumCombs, "]");
+    TORCH_CHECK(idx.size(0) == C && idx.size(1) == n_idx && idx.dtype() == torch::kInt32 &&
+                    idx.is_cuda(),
+                "reverb_forward_cuda: idx must be CUDA int32 [C, ", n_idx, "]");
+    scratch = scratch.contiguous();
+    fstore = fstore.contiguous();
+    idx = idx.contiguous();
+  }
 
   const int threads = 128;
   const int blocks = (static_cast<int>(C) + threads - 1) / threads;
@@ -133,15 +173,16 @@ torch::Tensor reverb_forward_cuda(
   AT_DISPATCH_FLOATING_TYPES(x_cont.scalar_type(), "reverb_forward_cuda", [&] {
     reverb_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
         x_cont.data_ptr<scalar_t>(), output.data_ptr<scalar_t>(), scratch.data_ptr<scalar_t>(),
+        fstore.data_ptr<scalar_t>(), idx.data_ptr<int>(),
         static_cast<int>(C), static_cast<int>(T), dims, static_cast<scalar_t>(feedback),
         static_cast<scalar_t>(damp), static_cast<scalar_t>(input_gain),
         static_cast<scalar_t>(allpass_fb), static_cast<scalar_t>(wet), static_cast<scalar_t>(dry));
   });
 
   if (x.dim() == 1) {
-    return output.squeeze(0);
+    return {output.squeeze(0), scratch, fstore, idx};
   }
-  return output;
+  return {output, scratch, fstore, idx};
 }
 
 }  // namespace torchfx

--- a/src/torchfx/_csrc/include/torchfx/compressor_kernel.h
+++ b/src/torchfx/_csrc/include/torchfx/compressor_kernel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <torch/types.h>
+#include <tuple>
 
 namespace torchfx {
 
@@ -16,7 +17,10 @@ namespace torchfx {
 //   g    = 10^((Lsc - L + makeup_db)/20);  y[n] = g * x[n]
 //
 // `inv_ratio` is 1/ratio (0 for an infinite-ratio limiter, avoiding inf math).
-torch::Tensor compressor_forward_cuda(
+// `state` is an optional [C, 3] = (y1, yL, ms) detector-state tensor, updated in
+// place for chunk-to-chunk streaming continuity (allocated fresh when undefined);
+// the (possibly allocated) state is returned alongside the output.
+std::tuple<torch::Tensor, torch::Tensor> compressor_forward_cuda(
     const torch::Tensor& x,
     double threshold_db,
     double inv_ratio,
@@ -25,6 +29,7 @@ torch::Tensor compressor_forward_cuda(
     double attack_coeff,
     double release_coeff,
     double rms_coeff,
-    int detector);
+    int detector,
+    const torch::Tensor& state = {});
 
 }  // namespace torchfx

--- a/src/torchfx/_csrc/include/torchfx/compressor_kernel.h
+++ b/src/torchfx/_csrc/include/torchfx/compressor_kernel.h
@@ -30,6 +30,6 @@ std::tuple<torch::Tensor, torch::Tensor> compressor_forward_cuda(
     double release_coeff,
     double rms_coeff,
     int detector,
-    const torch::Tensor& state = {});
+    const torch::Tensor& state = torch::Tensor());
 
 }  // namespace torchfx

--- a/src/torchfx/_csrc/include/torchfx/expander_kernel.h
+++ b/src/torchfx/_csrc/include/torchfx/expander_kernel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <torch/types.h>
+#include <tuple>
 
 namespace torchfx {
 
@@ -23,7 +24,9 @@ namespace torchfx {
 //
 // `slope` is ratio-1 (a large finite value stands in for an infinite-ratio gate, so the
 // kernel never does inf arithmetic); `floor_db` is the deepest attenuation in dB.
-torch::Tensor expander_forward_cuda(
+// `state` is an optional [C, 3] = (y1, yL, ms) detector-state tensor, updated in
+// place for chunk-to-chunk streaming continuity (allocated fresh when undefined).
+std::tuple<torch::Tensor, torch::Tensor> expander_forward_cuda(
     const torch::Tensor& x,
     double threshold_db,
     double slope,
@@ -32,6 +35,7 @@ torch::Tensor expander_forward_cuda(
     double attack_coeff,
     double release_coeff,
     double rms_coeff,
-    int detector);
+    int detector,
+    const torch::Tensor& state = {});
 
 }  // namespace torchfx

--- a/src/torchfx/_csrc/include/torchfx/expander_kernel.h
+++ b/src/torchfx/_csrc/include/torchfx/expander_kernel.h
@@ -36,6 +36,6 @@ std::tuple<torch::Tensor, torch::Tensor> expander_forward_cuda(
     double release_coeff,
     double rms_coeff,
     int detector,
-    const torch::Tensor& state = {});
+    const torch::Tensor& state = torch::Tensor());
 
 }  // namespace torchfx

--- a/src/torchfx/_csrc/include/torchfx/limiter_kernel.h
+++ b/src/torchfx/_csrc/include/torchfx/limiter_kernel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <torch/types.h>
+#include <tuple>
 
 namespace torchfx {
 
@@ -18,11 +19,16 @@ namespace torchfx {
 // The windowed target makes `g` start ramping down *before* a peak arrives (no transient
 // overshoot, no click), while the per-sample clamp guarantees |y[n]| <= threshold_lin — a
 // true brick wall — even though `g` itself is smoothed.
-torch::Tensor limiter_forward_cuda(
+// `state` is an optional [C, 1] = (g) gain-state tensor, updated in place for
+// chunk-to-chunk streaming continuity (unity-initialised when undefined). Note the
+// look-ahead window itself does not cross chunk boundaries; the per-sample clamp
+// guarantees the ceiling regardless.
+std::tuple<torch::Tensor, torch::Tensor> limiter_forward_cuda(
     const torch::Tensor& x,
     const torch::Tensor& peak_env,
     double threshold_lin,
     double attack_coeff,
-    double release_coeff);
+    double release_coeff,
+    const torch::Tensor& state = {});
 
 }  // namespace torchfx

--- a/src/torchfx/_csrc/include/torchfx/limiter_kernel.h
+++ b/src/torchfx/_csrc/include/torchfx/limiter_kernel.h
@@ -29,6 +29,6 @@ std::tuple<torch::Tensor, torch::Tensor> limiter_forward_cuda(
     double threshold_lin,
     double attack_coeff,
     double release_coeff,
-    const torch::Tensor& state = {});
+    const torch::Tensor& state = torch::Tensor());
 
 }  // namespace torchfx

--- a/src/torchfx/_csrc/include/torchfx/reverb_kernel.h
+++ b/src/torchfx/_csrc/include/torchfx/reverb_kernel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <torch/types.h>
+#include <tuple>
 
 namespace torchfx {
 
@@ -13,8 +14,10 @@ namespace torchfx {
 // y[n] = x[n]*dry + acc*wet
 //
 // The classic Schroeder/Moorer comb tunings (at 44.1 kHz) scaled to the signal's `fs`;
-// ring buffers live in a zero-initialised scratch tensor, one contiguous block per
-// channel. State is per-call (not carried across forward() calls).
+// ring buffers live in a scratch tensor, one contiguous block per channel. The
+// scratch / damping (`fstore`) / ring-position (`idx`) tensors are optional state:
+// when supplied they are updated in place so block-wise streaming is state-continuous
+// across forward() calls; when undefined they are allocated zeroed (one-shot use).
 
 // Comb / all-pass delay tunings in samples at 44.1 kHz (Freeverb defaults).
 constexpr int kReverbNumCombs = 8;
@@ -24,7 +27,7 @@ constexpr int kReverbCombTuning[kReverbNumCombs] = {1116, 1188, 1277, 1356,
 constexpr int kReverbAllpassTuning[kReverbNumAllpass] = {556, 441, 341, 225};
 constexpr double kReverbTuningFs = 44100.0;
 
-torch::Tensor reverb_forward_cuda(
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> reverb_forward_cuda(
     const torch::Tensor& x,
     int fs,
     double feedback,
@@ -32,6 +35,9 @@ torch::Tensor reverb_forward_cuda(
     double input_gain,
     double allpass_fb,
     double wet,
-    double dry);
+    double dry,
+    const torch::Tensor& scratch = {},
+    const torch::Tensor& fstore = {},
+    const torch::Tensor& idx = {});
 
 }  // namespace torchfx

--- a/src/torchfx/_csrc/include/torchfx/reverb_kernel.h
+++ b/src/torchfx/_csrc/include/torchfx/reverb_kernel.h
@@ -36,8 +36,8 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> reverb_fo
     double allpass_fb,
     double wet,
     double dry,
-    const torch::Tensor& scratch = {},
-    const torch::Tensor& fstore = {},
-    const torch::Tensor& idx = {});
+    const torch::Tensor& scratch = torch::Tensor(),
+    const torch::Tensor& fstore = torch::Tensor(),
+    const torch::Tensor& idx = torch::Tensor());
 
 }  // namespace torchfx

--- a/src/torchfx/_ops.py
+++ b/src/torchfx/_ops.py
@@ -18,7 +18,7 @@ cascades.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import torch
 
@@ -278,6 +278,24 @@ def delay_line_forward(
     return result_2d.reshape(original_shape)
 
 
+def _cached_state(holder: dict[str, Any] | None, key: str, x_native: Tensor) -> Tensor | None:
+    """Fetch a cached per-channel state tensor compatible with ``x_native``.
+
+    Returns ``None`` (fresh start) when there is no holder, no cached entry, or the
+    cached entry no longer matches the input's channel count / dtype / device —
+    self-healing when the caller's input shape changes between chunks.
+
+    """
+    if holder is None:
+        return None
+    st = holder.get(key)
+    if not isinstance(st, torch.Tensor):
+        return None
+    if st.size(0) != x_native.size(0) or st.dtype != x_native.dtype or st.device != x_native.device:
+        return None
+    return st
+
+
 def compressor_forward(
     x: Tensor,
     threshold_db: float,
@@ -288,13 +306,17 @@ def compressor_forward(
     release_coeff: float,
     rms_coeff: float,
     detector: int,
+    state: dict[str, Tensor] | None = None,
 ) -> Tensor:
     """Dispatch the compressor to the native kernel (CUDA or CPU).
 
     Ballistics coefficients are precomputed by the caller. ``detector`` is 0 (peak)
     or 1 (rms); ``inv_ratio`` is ``1 / ratio`` (0 for an infinite-ratio limiter, so
-    the kernel never does ``inf`` arithmetic). Returns the processed tensor with the
-    input shape and dtype preserved.
+    the kernel never does ``inf`` arithmetic). ``state`` is an optional mutable
+    holder owned by the effect: the kernel's per-channel detector state
+    ``(y1, yL, ms)`` is read from and stored back into it so block-wise streaming
+    is state-continuous across calls. Returns the processed tensor with the input
+    shape and dtype preserved.
 
     """
     if x.ndim < 1:
@@ -314,17 +336,35 @@ def compressor_forward(
     native_dtype = torch.float64 if x_2d.dtype == torch.float64 else torch.float32
     x_native = x_2d if x_2d.dtype == native_dtype else x_2d.to(dtype=native_dtype)
 
-    result_native: Tensor = _ext.compressor_forward(
-        x_native,
-        threshold_db,
-        inv_ratio,
-        knee_db,
-        makeup_db,
-        attack_coeff,
-        release_coeff,
-        rms_coeff,
-        detector,
-    )
+    st = _cached_state(state, "detector", x_native)
+    result_native: Tensor
+    if st is None:
+        result_native, st_out = _ext.compressor_forward(
+            x_native,
+            threshold_db,
+            inv_ratio,
+            knee_db,
+            makeup_db,
+            attack_coeff,
+            release_coeff,
+            rms_coeff,
+            detector,
+        )
+    else:
+        result_native, st_out = _ext.compressor_forward(
+            x_native,
+            threshold_db,
+            inv_ratio,
+            knee_db,
+            makeup_db,
+            attack_coeff,
+            release_coeff,
+            rms_coeff,
+            detector,
+            st,
+        )
+    if state is not None:
+        state["detector"] = st_out
     result_2d = result_native if result_native.dtype == x.dtype else result_native.to(dtype=x.dtype)
 
     if len(original_shape) == 1:
@@ -344,14 +384,17 @@ def expander_forward(
     release_coeff: float,
     rms_coeff: float,
     detector: int,
+    state: dict[str, Tensor] | None = None,
 ) -> Tensor:
     """Dispatch the downward expander / gate to the native kernel (CUDA or CPU).
 
     Ballistics coefficients are precomputed by the caller. ``detector`` is 0 (peak)
     or 1 (rms); ``slope`` is ``ratio - 1`` (a large finite value stands in for an
     infinite-ratio gate, so the kernel never does ``inf`` arithmetic); ``floor_db`` is
-    the deepest attenuation in dB. Returns the processed tensor with the input shape
-    and dtype preserved.
+    the deepest attenuation in dB. ``state`` is an optional mutable holder owned by
+    the effect: the kernel's per-channel detector state ``(y1, yL, ms)`` is read from
+    and stored back into it so block-wise streaming is state-continuous across calls.
+    Returns the processed tensor with the input shape and dtype preserved.
 
     """
     if x.ndim < 1:
@@ -371,17 +414,35 @@ def expander_forward(
     native_dtype = torch.float64 if x_2d.dtype == torch.float64 else torch.float32
     x_native = x_2d if x_2d.dtype == native_dtype else x_2d.to(dtype=native_dtype)
 
-    result_native: Tensor = _ext.expander_forward(
-        x_native,
-        threshold_db,
-        slope,
-        knee_db,
-        floor_db,
-        attack_coeff,
-        release_coeff,
-        rms_coeff,
-        detector,
-    )
+    st = _cached_state(state, "detector", x_native)
+    result_native: Tensor
+    if st is None:
+        result_native, st_out = _ext.expander_forward(
+            x_native,
+            threshold_db,
+            slope,
+            knee_db,
+            floor_db,
+            attack_coeff,
+            release_coeff,
+            rms_coeff,
+            detector,
+        )
+    else:
+        result_native, st_out = _ext.expander_forward(
+            x_native,
+            threshold_db,
+            slope,
+            knee_db,
+            floor_db,
+            attack_coeff,
+            release_coeff,
+            rms_coeff,
+            detector,
+            st,
+        )
+    if state is not None:
+        state["detector"] = st_out
     result_2d = result_native if result_native.dtype == x.dtype else result_native.to(dtype=x.dtype)
 
     if len(original_shape) == 1:
@@ -397,6 +458,7 @@ def limiter_forward(
     attack_coeff: float,
     release_coeff: float,
     lookahead_samples: int,
+    state: dict[str, Tensor] | None = None,
 ) -> Tensor:
     """Dispatch the look-ahead brick-wall limiter to the native kernel (CUDA or CPU).
 
@@ -404,8 +466,11 @@ def limiter_forward(
     with a vectorised forward max-pool (so the gain is reduced *before* a peak arrives);
     the native kernel then runs only the sequential gain recurrence (attack/release
     smoothing plus a per-sample brick-wall clamp). ``threshold_lin`` is the linear
-    ceiling, ``lookahead_samples`` is ``L``. Returns the processed tensor with the input
-    shape and dtype preserved.
+    ceiling, ``lookahead_samples`` is ``L``. ``state`` is an optional mutable holder
+    owned by the effect: the per-channel smoothed gain ``g`` is carried across calls so
+    block-wise streaming has release continuity. The look-ahead window itself does not
+    cross chunk boundaries (the per-sample clamp guarantees the ceiling regardless).
+    Returns the processed tensor with the input shape and dtype preserved.
 
     """
     if x.ndim < 1:
@@ -436,9 +501,18 @@ def limiter_forward(
     else:
         peak_env = abs_x
 
-    result_native: Tensor = _ext.limiter_forward(
-        x_native, peak_env.contiguous(), threshold_lin, attack_coeff, release_coeff
-    )
+    st = _cached_state(state, "gain", x_native)
+    result_native: Tensor
+    if st is None:
+        result_native, st_out = _ext.limiter_forward(
+            x_native, peak_env.contiguous(), threshold_lin, attack_coeff, release_coeff
+        )
+    else:
+        result_native, st_out = _ext.limiter_forward(
+            x_native, peak_env.contiguous(), threshold_lin, attack_coeff, release_coeff, st
+        )
+    if state is not None:
+        state["gain"] = st_out
     result_2d = result_native if result_native.dtype == x.dtype else result_native.to(dtype=x.dtype)
 
     if len(original_shape) == 1:
@@ -457,12 +531,16 @@ def reverb_forward(
     allpass_fb: float,
     wet: float,
     dry: float,
+    state: dict[str, Any] | None = None,
 ) -> Tensor:
     """Dispatch the Freeverb-style reverb to the native kernel (CUDA or CPU).
 
     Eight parallel low-pass-feedback comb filters and four series all-pass diffusers per
     channel, with comb/all-pass tunings scaled to ``fs``. ``feedback`` and ``damp`` set the
-    decay length and high-frequency damping; ``wet``/``dry`` mix the result. Returns the
+    decay length and high-frequency damping; ``wet``/``dry`` mix the result. ``state`` is
+    an optional mutable holder owned by the effect: the comb/all-pass delay lines,
+    damping state, and ring positions are carried across calls so block-wise streaming
+    is state-continuous (the reverb tail flows across chunk boundaries). Returns the
     processed tensor with the input shape and dtype preserved.
 
     """
@@ -482,9 +560,36 @@ def reverb_forward(
     native_dtype = torch.float64 if x_2d.dtype == torch.float64 else torch.float32
     x_native = x_2d if x_2d.dtype == native_dtype else x_2d.to(dtype=native_dtype)
 
-    result_native: Tensor = _ext.reverb_forward(
-        x_native, int(fs), feedback, damp, input_gain, allpass_fb, wet, dry
-    )
+    # Cached delay-line state is only reusable for the same fs (the scratch width is
+    # fs-dependent); a stale-fs cache is dropped here, the C++ TORCH_CHECK backstops.
+    scratch = _cached_state(state, "scratch", x_native)
+    fstore = _cached_state(state, "fstore", x_native)
+    idx = state.get("idx") if state is not None else None
+    same_fs = state is not None and state.get("_fs_marker") == int(fs)
+    result_native: Tensor
+    if scratch is None or fstore is None or idx is None or not same_fs:
+        result_native, scratch_out, fstore_out, idx_out = _ext.reverb_forward(
+            x_native, int(fs), feedback, damp, input_gain, allpass_fb, wet, dry
+        )
+    else:
+        result_native, scratch_out, fstore_out, idx_out = _ext.reverb_forward(
+            x_native,
+            int(fs),
+            feedback,
+            damp,
+            input_gain,
+            allpass_fb,
+            wet,
+            dry,
+            scratch,
+            fstore,
+            idx,
+        )
+    if state is not None:
+        state["scratch"] = scratch_out
+        state["fstore"] = fstore_out
+        state["idx"] = idx_out
+        state["_fs_marker"] = int(fs)
     result_2d = result_native if result_native.dtype == x.dtype else result_native.to(dtype=x.dtype)
 
     if len(original_shape) == 1:

--- a/src/torchfx/batch.py
+++ b/src/torchfx/batch.py
@@ -32,6 +32,30 @@ from torchfx.wave import Wave
 __all__ = ["batch_process"]
 
 
+def _reject_channel_coupled(effect: nn.Module) -> None:
+    """Raise if ``effect`` (or any submodule) aggregates across channels.
+
+    Batched processing concatenates independent signals on the channel axis, so an
+    effect that couples channels — a global-peak/RMS/percentile ``Normalize`` —
+    would mix statistics across signals and silently produce wrong output.
+    Per-channel strategies are safe and pass.
+
+    """
+    from torchfx.effect import Normalize, PerChannelNormalizationStrategy
+
+    for module in effect.modules():
+        if isinstance(module, Normalize) and not isinstance(
+            module.strategy, PerChannelNormalizationStrategy
+        ):
+            raise ValueError(
+                f"batch_process cannot apply a channel-coupled effect: "
+                f"{type(module).__name__} with {type(module.strategy).__name__} "
+                "aggregates across all channels, so batched signals would leak into "
+                "each other. Use PerChannelNormalizationStrategy or apply the effect "
+                "per signal."
+            )
+
+
 def batch_process(waves: Sequence[Wave], effect: nn.Module) -> list[Wave]:
     """Apply ``effect`` to many :class:`~torchfx.Wave` signals in one batched launch.
 
@@ -80,6 +104,8 @@ def batch_process(waves: Sequence[Wave], effect: nn.Module) -> list[Wave]:
     """
     if len(waves) == 0:
         raise ValueError("batch_process requires at least one Wave.")
+
+    _reject_channel_coupled(effect)
 
     fs = waves[0].fs
     device = waves[0].ys.device

--- a/src/torchfx/effect.py
+++ b/src/torchfx/effect.py
@@ -123,6 +123,7 @@ from __future__ import annotations
 import abc
 import math
 from collections.abc import Callable
+from typing import Any
 
 import torch
 from torch import Tensor, nn
@@ -855,8 +856,10 @@ class Reverb(FX):
     Notes
     -----
     Each channel is processed independently with identical tunings (no stereo-width spread
-    — a possible follow-up). State is reset per ``forward`` call, so block-wise streaming
-    is not state-continuous across chunks. This is a **breaking change** from the pre-0.7
+    — a possible follow-up). The comb/all-pass delay-line state is carried across
+    ``forward`` calls, so block-wise streaming is state-continuous (the tail flows across
+    chunk boundaries); call :meth:`reset_state` to cut the tail when switching sources.
+    The constructor signature is a **breaking change** from the pre-0.7
     ``Reverb(delay, decay, mix)`` API.
 
     Examples
@@ -900,6 +903,19 @@ class Reverb(FX):
         self.damping = float(damping)
         self.mix = float(mix)
         self.fs = fs
+        # Comb/all-pass delay lines, damping state, and ring positions, carried
+        # across forward calls so the reverb tail flows across chunk boundaries.
+        # See reset_state().
+        self._stream_state: dict[str, Any] = {}
+
+    def reset_state(self) -> None:
+        """Clear the accumulated delay-line state (cut the reverb tail).
+
+        Call when switching audio sources or seeking; ``Wave`` materialisation and
+        ``StreamProcessor`` file boundaries call this automatically.
+
+        """
+        self._stream_state.clear()
 
     @override
     @torch.no_grad()
@@ -926,6 +942,7 @@ class Reverb(FX):
             self._ALLPASS_FB,
             self.mix,  # wet
             1.0 - self.mix,  # dry
+            state=self._stream_state,
         )
 
 
@@ -1611,8 +1628,8 @@ class Compressor(FX):
     :math:`y[n] = g[n]\, x[n]`.
 
     This is a **zero-latency feed-forward** design (no look-ahead). The ballistics
-    state is reset on each ``forward`` call, so block-wise streaming is *not*
-    state-continuous across chunks (a follow-up could thread the state in/out).
+    state is carried across ``forward`` calls, so block-wise streaming is
+    state-continuous across chunks; call :meth:`reset_state` when switching sources.
 
     Examples
     --------
@@ -1686,6 +1703,9 @@ class Compressor(FX):
         self._aRMS = 0.0
         self._last_fs: int | None = None
         self._needs_calculation = True
+        # Per-channel detector state (y1, yL, ms), carried across forward calls so
+        # block-wise streaming is state-continuous. See reset_state().
+        self._stream_state: dict[str, Tensor] = {}
 
     def _compute_coeffs(self) -> None:
         """Derive attack/release/RMS coefficients from the times and ``fs``."""
@@ -1697,6 +1717,15 @@ class Compressor(FX):
         self._aRMS = 0.0 if self.attack == 0 else math.exp(-1.0 / (self.attack * fs))
         self._last_fs = fs
         self._needs_calculation = False
+
+    def reset_state(self) -> None:
+        """Clear the accumulated detector state.
+
+        Call when switching audio sources or seeking; ``Wave`` materialisation and
+        ``StreamProcessor`` file boundaries call this automatically.
+
+        """
+        self._stream_state.clear()
 
     @override
     @torch.no_grad()
@@ -1710,6 +1739,7 @@ class Compressor(FX):
             if self.fs <= 0:
                 raise ValueError("Sample rate (fs) must be positive.")
             self._compute_coeffs()
+            self.reset_state()  # ballistics changed: old detector state is invalid
 
         from torchfx._ops import compressor_forward
 
@@ -1723,6 +1753,7 @@ class Compressor(FX):
             self._aR,
             self._aRMS,
             1 if self.detector == "rms" else 0,
+            state=self._stream_state,
         )
 
 
@@ -1801,8 +1832,8 @@ class Expander(FX):
     clamped to ``floor`` (``g_{dB} \ge`` floor), and :math:`y[n] = 10^{g_{dB}/20}\,x[n]`.
 
     This is a **zero-latency feed-forward** design (no look-ahead). The ballistics state
-    is reset on each ``forward`` call, so block-wise streaming is *not* state-continuous
-    across chunks (see the compressor streaming follow-up).
+    is carried across ``forward`` calls, so block-wise streaming is state-continuous
+    across chunks (call :meth:`reset_state` when switching sources) (see the compressor streaming follow-up).
 
     Examples
     --------
@@ -1880,6 +1911,9 @@ class Expander(FX):
         self._aRMS = 0.0
         self._last_fs: int | None = None
         self._needs_calculation = True
+        # Per-channel detector state (y1, yL, ms), carried across forward calls so
+        # block-wise streaming is state-continuous. See reset_state().
+        self._stream_state: dict[str, Tensor] = {}
 
     def _compute_coeffs(self) -> None:
         """Derive attack/release/RMS coefficients from the times and ``fs``."""
@@ -1891,6 +1925,15 @@ class Expander(FX):
         self._aRMS = 0.0 if self.attack == 0 else math.exp(-1.0 / (self.attack * fs))
         self._last_fs = fs
         self._needs_calculation = False
+
+    def reset_state(self) -> None:
+        """Clear the accumulated detector state.
+
+        Call when switching audio sources or seeking; ``Wave`` materialisation and
+        ``StreamProcessor`` file boundaries call this automatically.
+
+        """
+        self._stream_state.clear()
 
     @override
     @torch.no_grad()
@@ -1904,6 +1947,7 @@ class Expander(FX):
             if self.fs <= 0:
                 raise ValueError("Sample rate (fs) must be positive.")
             self._compute_coeffs()
+            self.reset_state()  # ballistics changed: old detector state is invalid
 
         from torchfx._ops import expander_forward
 
@@ -1917,6 +1961,7 @@ class Expander(FX):
             self._aR,
             self._aRMS,
             1 if self.detector == "rms" else 0,
+            state=self._stream_state,
         )
 
 
@@ -2036,8 +2081,11 @@ class Limiter(FX):
 
     This is a **peak** (not true-peak / oversampled) limiter, so inter-sample peaks may
     slightly exceed the ceiling after conversion to analog (true-peak limiting is a possible
-    follow-up). The output is time-aligned with the input (no net latency). Ballistics state
-    is reset per ``forward`` call (not state-continuous across streaming chunks).
+    follow-up). The output is time-aligned with the input (no net latency). The smoothed
+    gain is carried across ``forward`` calls for release continuity in block-wise
+    streaming; the look-ahead window itself does not cross chunk boundaries (the
+    per-sample clamp guarantees the ceiling regardless). Call :meth:`reset_state` when
+    switching sources.
 
     Examples
     --------
@@ -2079,6 +2127,9 @@ class Limiter(FX):
         self._lookahead_samples = 0
         self._last_fs: int | None = None
         self._needs_calculation = True
+        # Per-channel smoothed gain g, carried across forward calls so block-wise
+        # streaming has release continuity. See reset_state().
+        self._stream_state: dict[str, Tensor] = {}
 
     def _compute_coeffs(self) -> None:
         """Derive ceiling, attack/release coefficients and look-ahead samples from
@@ -2094,6 +2145,15 @@ class Limiter(FX):
         self._last_fs = fs
         self._needs_calculation = False
 
+    def reset_state(self) -> None:
+        """Clear the accumulated gain state.
+
+        Call when switching audio sources or seeking; ``Wave`` materialisation and
+        ``StreamProcessor`` file boundaries call this automatically.
+
+        """
+        self._stream_state.clear()
+
     @override
     @torch.no_grad()
     def forward(self, waveform: Tensor) -> Tensor:
@@ -2106,6 +2166,7 @@ class Limiter(FX):
             if self.fs <= 0:
                 raise ValueError("Sample rate (fs) must be positive.")
             self._compute_coeffs()
+            self.reset_state()  # ballistics changed: old gain state is invalid
 
         from torchfx._ops import limiter_forward
 
@@ -2115,4 +2176,5 @@ class Limiter(FX):
             self._attack_coeff,
             self._release_coeff,
             self._lookahead_samples,
+            state=self._stream_state,
         )

--- a/src/torchfx/effect.py
+++ b/src/torchfx/effect.py
@@ -543,12 +543,15 @@ class Normalize(FX):
         assert peak > 0, "Peak value must be positive."
         self.peak = peak
 
-        if callable(strategy):
+        # Wrap only plain callables: NormalizationStrategy instances are themselves
+        # callable, and wrapping them in CustomNormalizationStrategy would erase
+        # their type (PerChannel vs global matters to e.g. batch_process).
+        if strategy is not None and not isinstance(strategy, NormalizationStrategy):
+            if not callable(strategy):
+                raise TypeError("Strategy must be an instance of NormalizationStrategy.")
             strategy = CustomNormalizationStrategy(strategy)
 
         self.strategy = strategy or PeakNormalizationStrategy()
-        if not isinstance(self.strategy, NormalizationStrategy):
-            raise TypeError("Strategy must be an instance of NormalizationStrategy.")
 
     @override
     @torch.no_grad()

--- a/src/torchfx/filter/__base.py
+++ b/src/torchfx/filter/__base.py
@@ -415,6 +415,32 @@ class AbstractFilter(FX, abc.ABC):
     # against ``fs`` on every forward so a filter reused across sample rates
     # recomputes its coefficients instead of silently applying stale ones.
     _coeff_fs: int | None = None
+    # Design-parameter snapshot the current coefficients were computed from
+    # (see ``_design_fingerprint``); compared on forward so mutating e.g.
+    # ``cutoff`` or ``order`` after the first call triggers a redesign.
+    _coeff_fingerprint: tuple[tuple[str, object], ...] | None = None
+
+    def _design_fingerprint(self) -> tuple[tuple[str, object], ...]:
+        """Snapshot the public scalar design parameters of this filter.
+
+        Collects plain-value public attributes (``cutoff``, ``order``, ``q``,
+        ``btype``, ...) so the forward guard can detect post-design mutation.
+        Tensors, modules, and private attributes are excluded. ``fs`` is part
+        of the snapshot but is also tracked separately via ``_coeff_fs``.
+
+        """
+        items: list[tuple[str, object]] = []
+        for k in sorted(self.__dict__):
+            if k.startswith("_"):
+                continue
+            v = self.__dict__[k]
+            if isinstance(v, (int, float, complex, str, bool, type(None))):
+                items.append((k, v))
+            elif isinstance(v, (tuple, list)) and all(
+                isinstance(e, (int, float, str, bool)) for e in v
+            ):
+                items.append((k, tuple(v)))
+        return tuple(items)
 
     @property
     def _has_computed_coeff(self) -> bool:

--- a/src/torchfx/filter/_fftconv.py
+++ b/src/torchfx/filter/_fftconv.py
@@ -129,7 +129,7 @@ def fft_conv1d(
     # FFT convolution via element-wise complex multiply (cross-correlation).
     frames_z = torch.fft.rfft(frames, dim=-1)  # [B, C, F, freq_bins]
     out_z = frames_z * kernel_z.conj()  # broadcast over B, C, F
-    out = torch.fft.irfft(out_z, n=block_size, dim=-1)  # [B, C, F, block_size]
+    out: Tensor = torch.fft.irfft(out_z, n=block_size, dim=-1)  # [B, C, F, block_size]
 
     # Discard circular convolution artifacts (last kernel_size - 1 samples).
     out = out[..., :fold_stride]
@@ -137,5 +137,4 @@ def fft_conv1d(
 
     # Trim to exact target length.
     target_length = length - kernel_size + 1
-    out = out[..., :target_length]
-    return Tensor(out)
+    return out[..., :target_length]

--- a/src/torchfx/filter/biquad.py
+++ b/src/torchfx/filter/biquad.py
@@ -192,11 +192,18 @@ class Biquad(AbstractFilter):
         """
         if self.fs is None:
             raise ValueError("Sample rate (fs) must be set before filtering.")
-        # Recompute when coefficients are missing or were designed for a
-        # different sampling rate, so a reused biquad never applies stale taps.
-        if self._sos is None or self.fs != self._coeff_fs:
+        # Recompute when coefficients are missing, were designed for a
+        # different sampling rate, or a design parameter (cutoff, q, gain, ...)
+        # was mutated after the last design — a reused or mutated biquad never
+        # applies stale taps.
+        if (
+            self._sos is None
+            or self.fs != self._coeff_fs
+            or self._design_fingerprint() != self._coeff_fingerprint
+        ):
             self.compute_coefficients()
             self._coeff_fs = self.fs
+            self._coeff_fingerprint = self._design_fingerprint()
             self._sos_device_cache = None
             # Coefficients changed: accumulated DF1 state no longer matches.
             self._state_x = None

--- a/src/torchfx/filter/fir.py
+++ b/src/torchfx/filter/fir.py
@@ -1020,3 +1020,26 @@ class DesignableFIR(FIR):
         )
         assert self.b is not None, "Filter coefficients (b) must be computed."
         self.kernel = torch.as_tensor(self.b, dtype=torch.float32).clone().flip(0)[None, None, :]
+        self._coeff_fs = self.fs
+
+    @override
+    @torch.no_grad()
+    def forward(self, x: Tensor) -> Tensor:
+        if self.fs is None:
+            raise ValueError(
+                "Sampling frequency (fs) must be set before filtering. Set fs "
+                "explicitly or use the filter in a Wave pipeline (wave | filter)."
+            )
+
+        # Redesign when coefficients are missing, were designed for a different
+        # sampling rate, or a design parameter (cutoff, num_taps, window, ...)
+        # was mutated after the last design — same contract as IIR.forward /
+        # Biquad.forward.
+        if (
+            self.b is None
+            or self.fs != self._coeff_fs
+            or self._design_fingerprint() != self._coeff_fingerprint
+        ):
+            self.compute_coefficients()
+
+        return super().forward(x)

--- a/src/torchfx/filter/fused.py
+++ b/src/torchfx/filter/fused.py
@@ -43,13 +43,17 @@ class FusedSOSCascade(nn.Module):
         if not filters:
             raise ValueError("FusedSOSCascade requires at least one IIR filter")
 
-        sos_parts: list[Tensor] = []
-        fs_val: int | None = None
-
         for f in filters:
             if not hasattr(f, "_sos"):
                 raise TypeError(f"Expected filter with SOS coefficients, got {type(f).__name__}")
 
+        # Keep the source filters (plain list — not registered as submodules) so
+        # the cascade can re-derive its SOS matrix when the sampling rate changes.
+        self._filters: list[IIR | Biquad] = list(filters)
+        self._gain: float = gain
+
+        fs_val: int | None = None
+        for f in filters:
             # Ensure coefficients are computed.
             if f._sos is None:
                 if f.fs is None:
@@ -58,9 +62,8 @@ class FusedSOSCascade(nn.Module):
                         "Set fs before fusing."
                     )
                 f.compute_coefficients()
-
-            assert f._sos is not None
-            sos_parts.append(f._sos)
+                f._coeff_fs = f.fs
+                f._coeff_fingerprint = f._design_fingerprint()
 
             # Validate consistent sampling frequency.
             if f.fs is not None:
@@ -71,17 +74,11 @@ class FusedSOSCascade(nn.Module):
                         f"Cannot fuse filters with different sample rates: {fs_val} vs {f.fs}"
                     )
 
-        # Concatenate all SOS sections: [K_total, 6]. torch.cat copies, so the
-        # source filters' coefficients are never mutated by the gain fold below.
-        self._sos: Tensor = torch.cat(sos_parts, dim=0).to(dtype=torch.float64)
-        # Fold a static scalar gain (e.g. a `Gain` between fused filters) into the
-        # LAST section's numerator. A scalar commutes through the linear cascade, so
-        # this is exact; folding into the last section scales only the final output,
-        # avoiding any intermediate over/underflow the gain might otherwise cause.
-        if gain != 1.0:
-            self._sos[-1, :3] *= gain
+        self._sos: Tensor = self._build_sos()
         self._num_sections: int = self._sos.shape[0]
         self.fs: int | None = fs_val
+        # Sampling rate the fused SOS matrix was built for (see forward).
+        self._coeff_fs: int | None = fs_val
 
         # Cached device-matched copy — avoids per-forward .to() calls.
         self._sos_device_cache: Tensor | None = None
@@ -90,6 +87,50 @@ class FusedSOSCascade(nn.Module):
         self._state_x: Tensor | None = None
         self._state_y: Tensor | None = None
         self._stateful: bool = False
+
+    def _build_sos(self) -> Tensor:
+        """Concatenate the source filters' SOS rows and fold the static gain.
+
+        ``torch.cat`` copies, so the source filters' coefficients are never mutated
+        by the gain fold below.
+
+        """
+        sos_parts: list[Tensor] = []
+        for f in self._filters:
+            assert f._sos is not None
+            sos_parts.append(f._sos)
+        sos = torch.cat(sos_parts, dim=0).to(dtype=torch.float64)
+        # Fold a static scalar gain (e.g. a `Gain` between fused filters) into the
+        # LAST section's numerator. A scalar commutes through the linear cascade, so
+        # this is exact; folding into the last section scales only the final output,
+        # avoiding any intermediate over/underflow the gain might otherwise cause.
+        if self._gain != 1.0:
+            sos[-1, :3] *= self._gain
+        return sos
+
+    def _recompute(self) -> None:
+        """Re-derive the fused SOS matrix for the current ``fs``.
+
+        Propagates ``fs`` to the source filters, recomputes their coefficients, and
+        rebuilds the concatenated matrix. Accumulated DF1 state and the device cache
+        no longer match the new coefficients, so both are dropped.
+
+        """
+        assert self.fs is not None
+        for f in self._filters:
+            f.fs = self.fs
+            f.compute_coefficients()
+            f._coeff_fs = f.fs
+            f._coeff_fingerprint = f._design_fingerprint()
+            f._sos_device_cache = None
+            f._state_x = None
+            f._state_y = None
+        self._sos = self._build_sos()
+        self._num_sections = self._sos.shape[0]
+        self._coeff_fs = self.fs
+        self._sos_device_cache = None
+        self._state_x = None
+        self._state_y = None
 
     @classmethod
     def from_chain(cls, chain: nn.Sequential | nn.Module) -> FusedSOSCascade:
@@ -132,6 +173,13 @@ class FusedSOSCascade(nn.Module):
         carry state across chunks.
 
         """
+        # Recompute when the sampling rate changed after construction (e.g. a
+        # RealtimeProcessor assigning `effect.fs = config.sample_rate`). Without
+        # this guard the cascade would silently keep coefficients designed for
+        # the old rate — same contract as IIR.forward / Biquad.forward.
+        if self.fs is not None and self.fs != self._coeff_fs:
+            self._recompute()
+
         result, self._sos_device_cache, self._state_x, self._state_y = _sos_cascade_forward(
             x, self._sos, self._sos_device_cache, self._state_x, self._state_y
         )

--- a/src/torchfx/filter/iir.py
+++ b/src/torchfx/filter/iir.py
@@ -250,12 +250,18 @@ class IIR(AbstractFilter):
         if self.fs is None:
             raise ValueError(NONE_FS_ERR)
 
-        # Recompute when coefficients are missing or were designed for a
-        # different sampling rate. Without the fs check, a filter reused across
-        # sample rates would silently apply stale coefficients.
-        if self._sos is None or self.fs != self._coeff_fs:
+        # Recompute when coefficients are missing, were designed for a
+        # different sampling rate, or a design parameter (cutoff, order, ...)
+        # was mutated after the last design. Without these checks, a reused or
+        # mutated filter would silently apply stale coefficients.
+        if (
+            self._sos is None
+            or self.fs != self._coeff_fs
+            or self._design_fingerprint() != self._coeff_fingerprint
+        ):
             self.compute_coefficients()
             self._coeff_fs = self.fs
+            self._coeff_fingerprint = self._design_fingerprint()
             self._sos_device_cache = None  # invalidate after recomputation
             # Coefficients changed: accumulated DF1 state no longer matches.
             self._state_x = None

--- a/src/torchfx/realtime/ring_buffer.py
+++ b/src/torchfx/realtime/ring_buffer.py
@@ -1,14 +1,22 @@
-"""Lock-free SPSC ring buffer for real-time audio tensor transfer.
+"""Lockless SPSC ring buffer for real-time audio tensor transfer.
 
 This module provides a single-producer single-consumer (SPSC) ring buffer
 backed by pre-allocated PyTorch tensors. It is designed for real-time audio
 processing where an audio callback thread produces data and a processing
 thread consumes it.
 
+.. note::
+   The buffer takes no explicit locks, but it is **not** lock-free in the
+   formal sense: index updates are plain Python integer assignments whose
+   atomicity and ordering are guaranteed only by CPython's GIL. Under the
+   GIL the SPSC discipline (producer writes ``_write_idx`` only, consumer
+   writes ``_read_idx`` only) is safe. On a free-threaded (PEP 703 / nogil)
+   interpreter these accesses would need real atomics or explicit fences.
+
 Classes
 -------
 TensorRingBuffer
-    Lock-free SPSC ring buffer operating on PyTorch tensors.
+    Lockless SPSC ring buffer operating on PyTorch tensors.
 
 Examples
 --------
@@ -30,11 +38,13 @@ from torch import Tensor
 
 
 class TensorRingBuffer:
-    """Lock-free SPSC ring buffer for real-time audio tensor transfer.
+    """Lockless SPSC ring buffer for real-time audio tensor transfer.
 
     Uses separate read/write indices with a pre-allocated tensor backing
     store. In the SPSC model, only the producer writes ``_write_idx`` and
-    only the consumer writes ``_read_idx``, so no locks are needed.
+    only the consumer writes ``_read_idx``, so no explicit locks are taken.
+    Index updates rely on CPython's GIL for atomicity/ordering (see the
+    module docstring); this is not a formally lock-free structure.
 
     The capacity must be a power of 2 for efficient modular arithmetic
     (bitwise AND instead of modulo). If a non-power-of-2 value is provided,

--- a/src/torchfx/realtime/sounddevice_backend.py
+++ b/src/torchfx/realtime/sounddevice_backend.py
@@ -262,9 +262,13 @@ class SoundDeviceBackend(AudioBackend):
             torch.zeros(ch_out, buf, dtype=torch.float32) if ch_out > 0 else torch.empty(0)
         )
 
-        # Pre-allocate numpy view for output copy-back (channels, frames) order.
-        # We'll transpose into outdata at the end.
+        # Pre-allocate numpy views once — .numpy() creates a new ndarray object
+        # each call, which would be a per-callback allocation on the audio thread.
+        # Input view (channels, frames) for copy-in, output view for copy-back.
+        _in_np = _input_tensor.numpy() if ch_in > 0 else None
         _out_np = _output_tensor.numpy() if ch_out > 0 else None
+        # Reused empty tensor for the missing-side argument (no per-callback alloc).
+        _empty = torch.empty(0)
 
         def sd_callback(
             indata: NDArray[Any] | None,
@@ -287,19 +291,19 @@ class SoundDeviceBackend(AudioBackend):
                 )
 
             # Convert input: numpy (frames, channels) -> pre-allocated tensor (channels, frames)
-            if indata is not None:
+            if indata is not None and _in_np is not None:
                 if mono_in:
                     # Mono fast-path: no transpose needed, just copy the column
-                    np.copyto(_input_tensor.numpy()[0], indata[:, 0])
+                    np.copyto(_in_np[0], indata[:, 0])
                 else:
-                    np.copyto(_input_tensor.numpy(), indata.T)
+                    np.copyto(_in_np, indata.T)
 
             # Zero the output tensor in-place (no allocation)
             if outdata is not None:
                 _output_tensor.zero_()
 
-            in_t = _input_tensor if indata is not None else torch.empty(0)
-            out_t = _output_tensor if outdata is not None else torch.empty(0)
+            in_t = _input_tensor if indata is not None else _empty
+            out_t = _output_tensor if outdata is not None else _empty
             if accepts_status:
                 callback(in_t, out_t, frames, backend_status)
             else:

--- a/src/torchfx/typing.py
+++ b/src/torchfx/typing.py
@@ -122,7 +122,8 @@ class MusicalTime:
             If BPM is not positive.
 
         """
-        assert bpm > 0, "BPM must be positive"
+        if bpm <= 0:
+            raise ValueError(f"BPM must be positive, got {bpm}")
         beat_duration = 60.0 / bpm
         bar_duration = beat_duration * beats_per_bar
         return self.fraction() * bar_duration

--- a/src/torchfx/validation/validators.py
+++ b/src/torchfx/validation/validators.py
@@ -639,5 +639,4 @@ def validate_q_factor(
 
     """
     validate_positive(q, parameter_name)
-    if min_q is not None or max_q is not None:
-        validate_range(q, parameter_name, min_value=min_q, max_value=max_q)
+    validate_range(q, parameter_name, min_value=min_q, max_value=max_q)

--- a/src/torchfx/wave.py
+++ b/src/torchfx/wave.py
@@ -771,10 +771,12 @@ class Wave:
 
         if isinstance(f, AbstractFilter) and (fs_changed or not f._has_computed_coeff):
             f.compute_coefficients()
-            # Record the fs the coefficients were designed for so a subsequent
-            # direct forward() does not needlessly recompute (and so a genuine
-            # fs change is still detected on the direct-call path).
+            # Record the fs and design-parameter snapshot the coefficients were
+            # designed for so a subsequent direct forward() does not needlessly
+            # recompute (and so a genuine fs/parameter change is still detected
+            # on the direct-call path).
             f._coeff_fs = getattr(f, "fs", None)
+            f._coeff_fingerprint = f._design_fingerprint()
 
     def __len__(self) -> int:
         """Return the length, in samples, of the wave."""
@@ -1082,11 +1084,17 @@ class Wave:
             raise ValueError("No waves to merge. Provide at least one wave.")
 
         fs = waves[0].fs
+        device = waves[0].device
         for w in waves:
             if w.fs != fs:
                 raise ValueError(
                     f"Sampling frequency mismatch: {w.fs} != {fs}. "
                     "All waves must have the same sampling frequency."
+                )
+            if w.device != device:
+                raise ValueError(
+                    f"Device mismatch: {w.device} != {device}. "
+                    "All waves must be on the same device; move them with Wave.to() first."
                 )
 
         if split_channels:

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -1,0 +1,262 @@
+# ruff: noqa: A001
+"""Regression tests for the IS2-review fixes (issues #84, #85, #88, #90-#93).
+
+Each test pins one verified finding from the 2026-06 code review:
+
+- #84  FusedSOSCascade recomputes on fs change (the realtime ``effect.fs = ...``
+  assignment path).
+- #85  DesignableFIR redesigns on fs change and refuses to run undesigned.
+- #88  IIR/Biquad/DesignableFIR redesign when a design parameter is mutated
+  after the first forward.
+- #90  fft path matches scipy.lfilter for signals shorter than the kernel
+  (verified NOT a bug — pinned here so it stays correct).
+- #91  MusicalTime.duration_seconds raises ValueError (not assert) on bad BPM.
+- #92  batch_process rejects channel-coupled (global Normalize) effects.
+- #93  Wave.merge validates devices like it validates fs.
+
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from scipy import signal
+
+import torchfx as fx
+from torchfx.filter import FIR, DesignableFIR, LoButterworth
+from torchfx.filter.biquad import BiquadLPF
+from torchfx.filter.fused import FusedSOSCascade
+from torchfx.typing import MusicalTime
+
+
+def _signal(n: int = 2000, ch: int = 1) -> torch.Tensor:
+    g = torch.Generator().manual_seed(0)
+    return torch.randn(ch, n, generator=g, dtype=torch.float64)
+
+
+# --------------------------------------------------------------------------- #
+# #84 — FusedSOSCascade fs-change guard.                                      #
+# --------------------------------------------------------------------------- #
+
+
+class TestFusedCascadeFsChange:
+    def test_recomputes_on_fs_change(self):
+        """A fused cascade reused across sample rates matches a fresh design."""
+        x = _signal()
+        fused = FusedSOSCascade(
+            LoButterworth(cutoff=100, order=2, fs=1000),
+            BiquadLPF(cutoff=200, q=0.707, fs=1000),
+        )
+        fused(x)  # materialize at fs=1000
+        assert fused._coeff_fs == 1000
+
+        # The RealtimeProcessor path: a plain attribute assignment.
+        fused.fs = 2000
+        out_reused = fused(x)
+        assert fused._coeff_fs == 2000
+
+        fresh = FusedSOSCascade(
+            LoButterworth(cutoff=100, order=2, fs=2000),
+            BiquadLPF(cutoff=200, q=0.707, fs=2000),
+        )
+        torch.testing.assert_close(out_reused, fresh(x))
+
+    def test_fs_change_resets_state(self):
+        """Accumulated DF1 state is dropped with the stale coefficients."""
+        x = _signal()
+        fused = FusedSOSCascade(LoButterworth(cutoff=100, order=4, fs=1000))
+        for _ in range(3):
+            fused(x)
+        assert fused._state_y is not None
+
+        fused.fs = 2000
+        out_after = fused(x)
+
+        fresh = FusedSOSCascade(LoButterworth(cutoff=100, order=4, fs=2000))
+        torch.testing.assert_close(out_after, fresh(x))
+
+    def test_gain_fold_survives_recompute(self):
+        """The folded static gain is re-applied to the rebuilt SOS matrix."""
+        x = _signal()
+        fused = FusedSOSCascade(LoButterworth(cutoff=100, order=2, fs=1000), gain=0.5)
+        fused(x)
+        fused.fs = 2000
+        out = fused(x)
+
+        fresh = FusedSOSCascade(LoButterworth(cutoff=100, order=2, fs=2000), gain=0.5)
+        torch.testing.assert_close(out, fresh(x))
+
+    def test_no_rebuild_when_fs_unchanged(self):
+        """Repeated forwards at a fixed fs must not rebuild the SOS matrix."""
+        x = _signal()
+        fused = FusedSOSCascade(LoButterworth(cutoff=100, order=2, fs=1000))
+        fused(x)
+        sos_first = fused._sos
+        fused(x)
+        assert fused._sos is sos_first
+
+
+# --------------------------------------------------------------------------- #
+# #85 — DesignableFIR fs guard + no silent passthrough.                       #
+# --------------------------------------------------------------------------- #
+
+
+class TestDesignableFIRFsChange:
+    def test_redesigns_on_fs_change(self):
+        x = _signal()
+        reused = DesignableFIR(cutoff=100, num_taps=31, fs=1000)
+        reused(x)
+        assert reused._coeff_fs == 1000
+
+        reused.fs = 2000
+        out_reused = reused(x)
+        assert reused._coeff_fs == 2000
+
+        fresh = DesignableFIR(cutoff=100, num_taps=31, fs=2000)
+        torch.testing.assert_close(out_reused, fresh(x))
+
+    def test_undesigned_forward_raises(self):
+        """Fs=None + no design must raise, not pass audio through unfiltered."""
+        f = DesignableFIR(cutoff=100, num_taps=31)  # fs deferred
+        with pytest.raises(ValueError, match="fs"):
+            f(_signal())
+
+    def test_wave_pipe_still_designs(self):
+        """The Wave pipe path designs the deferred filter exactly once."""
+        data = _signal()
+        f = DesignableFIR(cutoff=100, num_taps=31)
+        out = (fx.Wave(data.clone(), fs=1000) | f).ys
+        fresh = DesignableFIR(cutoff=100, num_taps=31, fs=1000)
+        torch.testing.assert_close(out, fresh(data.clone()))
+
+
+# --------------------------------------------------------------------------- #
+# #88 — design-parameter mutation triggers redesign.                          #
+# --------------------------------------------------------------------------- #
+
+
+class TestParameterMutation:
+    def test_iir_cutoff_mutation(self):
+        x = _signal()
+        f = LoButterworth(cutoff=100, order=4, fs=1000)
+        f(x)
+        f.cutoff = 250
+        out = f(x)
+        fresh = LoButterworth(cutoff=250, order=4, fs=1000)
+        torch.testing.assert_close(out, fresh(x))
+
+    def test_iir_order_mutation(self):
+        x = _signal()
+        f = LoButterworth(cutoff=100, order=2, fs=1000)
+        f(x)
+        f.order = 6
+        out = f(x)
+        fresh = LoButterworth(cutoff=100, order=6, fs=1000)
+        torch.testing.assert_close(out, fresh(x))
+
+    def test_biquad_q_mutation(self):
+        x = _signal()
+        f = BiquadLPF(cutoff=100, q=0.707, fs=1000)
+        f(x)
+        f.q = 2.0
+        out = f(x)
+        fresh = BiquadLPF(cutoff=100, q=2.0, fs=1000)
+        torch.testing.assert_close(out, fresh(x))
+
+    def test_designable_fir_cutoff_mutation(self):
+        x = _signal()
+        f = DesignableFIR(cutoff=100, num_taps=31, fs=1000)
+        f(x)
+        f.cutoff = 250
+        out = f(x)
+        fresh = DesignableFIR(cutoff=250, num_taps=31, fs=1000)
+        torch.testing.assert_close(out, fresh(x))
+
+    def test_no_redesign_without_mutation(self):
+        x = _signal()
+        f = LoButterworth(cutoff=100, order=4, fs=1000)
+        f(x)
+        sos_first = f._sos
+        f(x)
+        assert f._sos is sos_first
+
+
+# --------------------------------------------------------------------------- #
+# #90 — short-signal FIR correctness (pinned: matches scipy.lfilter).         #
+# --------------------------------------------------------------------------- #
+
+
+class TestShortSignalFIR:
+    @pytest.mark.parametrize("T,K", [(1, 100), (5, 16), (3, 4), (50, 64)])
+    @pytest.mark.parametrize("conv_mode", ["fft", "direct"])
+    def test_matches_lfilter_when_signal_shorter_than_kernel(self, T, K, conv_mode):
+        b = np.ones(K) / K
+        x = np.random.RandomState(0).randn(T)
+        ref = signal.lfilter(b, [1.0], x)
+        out = FIR(b=b, conv_mode=conv_mode)(torch.tensor(x, dtype=torch.float64))
+        torch.testing.assert_close(
+            out, torch.tensor(ref, dtype=torch.float64), atol=1e-8, rtol=1e-6
+        )
+
+
+# --------------------------------------------------------------------------- #
+# #91 — MusicalTime contract.                                                 #
+# --------------------------------------------------------------------------- #
+
+
+class TestMusicalTimeValidation:
+    @pytest.mark.parametrize("bpm", [0, -1, -120.5])
+    def test_nonpositive_bpm_raises_value_error(self, bpm):
+        mt = MusicalTime.from_string("1/4")
+        with pytest.raises(ValueError, match="BPM must be positive"):
+            mt.duration_seconds(bpm)
+
+
+# --------------------------------------------------------------------------- #
+# #92 — batch_process channel-coupling guard.                                 #
+# --------------------------------------------------------------------------- #
+
+
+class TestBatchProcessGuard:
+    def _waves(self, n: int = 3) -> list[fx.Wave]:
+        g = torch.Generator().manual_seed(0)
+        return [fx.Wave(torch.randn(1, 512, generator=g), 48000) for _ in range(n)]
+
+    def test_global_normalize_rejected(self):
+        from torchfx.effect import Normalize
+
+        with pytest.raises(ValueError, match="channel-coupled"):
+            fx.batch_process(self._waves(), Normalize(peak=1.0))
+
+    def test_per_channel_normalize_allowed(self):
+        from torchfx.effect import Normalize, PerChannelNormalizationStrategy
+
+        out = fx.batch_process(
+            self._waves(), Normalize(peak=1.0, strategy=PerChannelNormalizationStrategy())
+        )
+        assert len(out) == 3
+
+    def test_filters_still_allowed(self):
+        out = fx.batch_process(self._waves(), LoButterworth(cutoff=4000, order=4))
+        assert len(out) == 3
+
+
+# --------------------------------------------------------------------------- #
+# #93 — Wave.merge device validation.                                         #
+# --------------------------------------------------------------------------- #
+
+
+class TestMergeDeviceValidation:
+    def test_same_device_ok(self):
+        a = fx.Wave(torch.randn(1, 100), 48000)
+        b = fx.Wave(torch.randn(1, 100), 48000)
+        merged = fx.Wave.merge([a, b], split_channels=True)
+        assert merged.channels() == 2
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a second device")
+    def test_device_mismatch_raises(self):
+        a = fx.Wave(torch.randn(1, 100), 48000)
+        b = fx.Wave(torch.randn(1, 100), 48000, device="cuda")
+        with pytest.raises(ValueError, match="[Dd]evice mismatch"):
+            fx.Wave.merge([a, b], split_channels=True)

--- a/tests/test_streaming_state.py
+++ b/tests/test_streaming_state.py
@@ -1,0 +1,160 @@
+# ruff: noqa: A001
+"""Streaming-state continuity for the dynamics effects and the reverb (#72 / #86).
+
+The native kernels now thread their per-channel recurrence state through the
+effect instance, so processing a signal in chunks must equal processing it in one
+shot — the property that makes ``StreamProcessor`` / ``RealtimeProcessor`` use of
+these effects artifact-free at chunk boundaries.
+
+Limiter caveat: its look-ahead window deliberately does not cross chunk
+boundaries (an exact match would require L samples of output latency), so chunked
+equality is only exact for ``lookahead=0``; with look-ahead we assert the
+brick-wall property and gain-state continuity instead.
+
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from torchfx.effect import Compressor, Expander, Gate, Limiter, Reverb
+
+
+def _signal(n: int = 8192, ch: int = 2, scale: float = 1.0) -> torch.Tensor:
+    g = torch.Generator().manual_seed(42)
+    return torch.randn(ch, n, generator=g) * scale
+
+
+def _chunked(effect, x: torch.Tensor, n_chunks: int = 4) -> torch.Tensor:
+    return torch.cat([effect(c) for c in torch.chunk(x, n_chunks, dim=1)], dim=1)
+
+
+class TestCompressorStreaming:
+    @pytest.mark.parametrize("detector", ["peak", "rms"])
+    def test_chunked_equals_oneshot(self, detector):
+        x = _signal(scale=2.0)
+        one = Compressor(threshold=-10, ratio=4, detector=detector, fs=48000)
+        chk = Compressor(threshold=-10, ratio=4, detector=detector, fs=48000)
+        torch.testing.assert_close(_chunked(chk, x), one(x))
+
+    def test_reset_state_restores_fresh_behavior(self):
+        x = _signal(scale=2.0)
+        eff = Compressor(threshold=-10, ratio=4, fs=48000)
+        first = eff(x)
+        eff.reset_state()
+        torch.testing.assert_close(eff(x), first)
+
+    def test_state_persists_without_reset(self):
+        """Without a reset, the second call continues from the first call's state."""
+        x = _signal(scale=2.0)
+        eff = Compressor(threshold=-10, ratio=4, release=0.2, fs=48000)
+        first = eff(x)
+        second = eff(x)  # detector envelope is already charged -> different output
+        assert not torch.allclose(first, second)
+
+    def test_channel_count_change_self_heals(self):
+        eff = Compressor(threshold=-10, ratio=4, fs=48000)
+        eff(_signal(ch=2, scale=2.0))
+        out = eff(_signal(ch=4, scale=2.0))  # stale [2,3] state must be dropped
+        assert out.shape == (4, 8192)
+
+
+class TestExpanderStreaming:
+    @pytest.mark.parametrize("cls,kwargs", [(Expander, {"ratio": 3.0}), (Gate, {})])
+    def test_chunked_equals_oneshot(self, cls, kwargs):
+        x = _signal(scale=0.1)
+        one = cls(threshold=-25, fs=48000, **kwargs)
+        chk = cls(threshold=-25, fs=48000, **kwargs)
+        torch.testing.assert_close(_chunked(chk, x), one(x))
+
+    def test_reset_state_restores_fresh_behavior(self):
+        x = _signal(scale=0.1)
+        eff = Expander(threshold=-25, ratio=3.0, fs=48000)
+        first = eff(x)
+        eff.reset_state()
+        torch.testing.assert_close(eff(x), first)
+
+
+class TestLimiterStreaming:
+    def test_chunked_equals_oneshot_no_lookahead(self):
+        x = _signal(scale=3.0)
+        one = Limiter(threshold=-1.0, lookahead=0.0, release=0.05, fs=48000)
+        chk = Limiter(threshold=-1.0, lookahead=0.0, release=0.05, fs=48000)
+        torch.testing.assert_close(_chunked(chk, x), one(x))
+
+    def test_brick_wall_holds_across_chunks_with_lookahead(self):
+        x = _signal(scale=3.0)
+        eff = Limiter(threshold=-1.0, lookahead=0.005, release=0.05, fs=48000)
+        out = _chunked(eff, x, n_chunks=8)
+        ceiling = 10 ** (-1.0 / 20)
+        assert out.abs().max() <= ceiling + 1e-4
+
+    def test_gain_state_carried(self):
+        """A loud first chunk leaves g < 1; a quiet second chunk shows the release
+        tail."""
+        loud = torch.ones(1, 4096) * 3.0
+        quiet = torch.ones(1, 4096) * 0.1
+
+        streaming = Limiter(threshold=-1.0, lookahead=0.0, release=0.5, fs=48000)
+        streaming(loud)
+        out_carried = streaming(quiet)
+
+        fresh = Limiter(threshold=-1.0, lookahead=0.0, release=0.5, fs=48000)
+        out_fresh = fresh(quiet)
+
+        # With carried gain the quiet chunk starts attenuated (release still recovering).
+        assert out_carried[0, 0] < out_fresh[0, 0]
+
+
+class TestReverbStreaming:
+    def test_chunked_equals_oneshot(self):
+        x = _signal()
+        one = Reverb(room_size=0.7, damping=0.4, mix=0.3, fs=48000)
+        chk = Reverb(room_size=0.7, damping=0.4, mix=0.3, fs=48000)
+        torch.testing.assert_close(_chunked(chk, x), one(x))
+
+    def test_tail_flows_across_chunks(self):
+        """After a burst, a silent chunk must contain the reverb tail (not silence)."""
+        burst = torch.zeros(1, 4096)
+        burst[0, 0] = 1.0
+        silence = torch.zeros(1, 4096)
+
+        eff = Reverb(room_size=0.8, damping=0.2, mix=1.0, fs=48000)
+        eff(burst)
+        tail = eff(silence)
+        assert tail.abs().max() > 1e-4
+
+    def test_reset_state_cuts_tail(self):
+        burst = torch.zeros(1, 4096)
+        burst[0, 0] = 1.0
+        silence = torch.zeros(1, 4096)
+
+        eff = Reverb(room_size=0.8, damping=0.2, mix=1.0, fs=48000)
+        eff(burst)
+        eff.reset_state()
+        tail = eff(silence)
+        torch.testing.assert_close(tail, silence)
+
+    def test_fs_change_invalidates_state(self):
+        """State from one fs (different scratch width) must not be reused at another."""
+        x = _signal(n=4096, ch=1)
+        eff = Reverb(room_size=0.7, fs=44100)
+        eff(x)
+        eff.fs = 48000
+        out = eff(x)  # must not crash; fresh state at the new fs
+        fresh = Reverb(room_size=0.7, fs=48000)
+        torch.testing.assert_close(out, fresh(x))
+
+
+class TestWaveIsolation:
+    def test_offline_wave_reuse_does_not_leak_state(self):
+        """Wave materialisation resets effect state, so reuse across Waves is clean."""
+        import torchfx as fx
+
+        data = _signal(scale=2.0)
+        eff = Compressor(threshold=-10, ratio=4, fs=48000)
+
+        out_a = (fx.Wave(data.clone(), fs=48000) | eff).ys
+        out_b = (fx.Wave(data.clone(), fs=48000) | eff).ys
+        torch.testing.assert_close(out_a, out_b)


### PR DESCRIPTION
## Summary

Fixes from the IS² 2026 pre-paper code review (issues #84–#96), plus the streaming-state work tracked in #72/#86 and a differentiable-DSP proof of concept.

### Correctness fixes
- **#84** `FusedSOSCascade` tracks `_coeff_fs`, keeps its source filters, and rebuilds its SOS matrix (re-applying the folded gain) when `fs` changes after construction — the `RealtimeProcessor` `effect.fs = ...` path no longer filters with coefficients designed for the old rate.
- **#85** `DesignableFIR` redesigns on fs/parameter change on the direct `forward()` path and raises instead of silently passing audio through its placeholder kernel when `fs` is unset.
- **#88** `AbstractFilter._design_fingerprint()`: mutating `cutoff`/`order`/`q` after the first forward now triggers a redesign (IIR, Biquad, DesignableFIR).
- **#87** Realtime callback no longer allocates (pre-allocated input numpy view + empty tensor).
- **#91–#96** `MusicalTime` raises `ValueError` per contract; `batch_process` rejects channel-coupled effects (and `Normalize` no longer type-erases strategy instances); `Wave.merge` validates devices; ring-buffer docs state GIL-dependence; dead validator condition removed; CUDA int-cast + epoch-wrap guards.
- **#90** verified **not a bug** (FFT path matches `scipy.lfilter` for `T<K` to 1e-10) — closed; pinned with regression tests.

### Streaming state (#72 / #86)
`Compressor`, `Expander`/`Gate`, `Limiter`, and `Reverb` now carry per-channel recurrence state across `forward()` calls (CPU + CUDA kernels, bindings, `_ops`, effects). Chunked processing is bit-identical to one-shot (limiter exact at `lookahead=0`; the look-ahead window doesn't cross chunk boundaries — the per-sample clamp guarantees the ceiling regardless). All four effects gained `reset_state()`; `Wave` materialisation and `StreamProcessor` boundaries reset automatically, so offline behavior is unchanged.

### Differentiable-DSP proof of concept
`examples/ddsp_graphic_eq.py`: a learnable RBJ parametric EQ (per-band fc/Q/gain as `nn.Parameter`, FLAMO-style stability maps) applied in the frequency domain, trained with a multi-resolution STFT loss to invert a hidden 4-band coloration — converges to a 0.04 dB mean-abs residual in ~120 Adam steps on CPU. Plain autograd end-to-end; the fast `no_grad` inference kernels are untouched.

## Validation
- Local (CPU-only box): 1411 passed; mypy `--strict`, ruff, black clean.
- **Alienware (RTX 3070, nvcc 12.4): full suite 1500 passed** (all CUDA tests included).
- CUDA streaming state: chunked-vs-one-shot **bit-exact (max err 0.0)** for all four effects on GPU; look-ahead limiter holds the −1 dBFS ceiling exactly across 8 chunk boundaries.

## Notes for reviewers
- New tests: `tests/test_streaming_state.py` (16), `tests/test_review_fixes.py` (28).
- The opt-in `TORCHFX_FUSED_SCAN` decoupled-look-back path got an epoch-wrap guard only; the planned soak (`benchmarks/slurm/soak_fused_scan.sbatch`) before default-on is still pending.
- `-ffast-math` review concluded: precision suite passes vs SciPy in FP64, so the flag change is deferred as benchmark-gated (changing it now would invalidate the checked-in benchmark JSONs mid-paper).

Closes #84, #85, #87, #88, #91, #92, #93, #94, #95, #96. Refs #72, #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)