### PR TITLE
fix: raise ValueError for non-positive BPM in MusicalTime.duration_seconds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `MusicalTime.duration_seconds` now raises `ValueError` on non-positive BPM as its
+  docstring promises, instead of asserting. The `assert` was silently stripped under
+  `python -O`, letting `bpm=0` reach the `60.0 / bpm` division (`ZeroDivisionError`).
+
 ## [0.7.0] - 2026-06-09
 
 ### Added

--- a/src/torchfx/typing.py
+++ b/src/torchfx/typing.py
@@ -122,7 +122,8 @@ class MusicalTime:
             If BPM is not positive.
 
         """
-        assert bpm > 0, "BPM must be positive"
+        if bpm <= 0:
+            raise ValueError("BPM must be positive")
         beat_duration = 60.0 / bpm
         bar_duration = beat_duration * beats_per_bar
         return self.fraction() * bar_duration

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -527,6 +527,16 @@ def test_musical_time_duration_calculation(time_str, bpm, expected_duration):
     assert mt.duration_seconds(bpm) == pytest.approx(expected_duration)
 
 
+@pytest.mark.parametrize("bpm", [0, -120])
+def test_musical_time_invalid_bpm(bpm):
+    """Test MusicalTime rejects non-positive BPM."""
+    from torchfx.typing import MusicalTime
+
+    mt = MusicalTime.from_string("1/4")
+    with pytest.raises(ValueError, match="BPM must be positive"):
+        mt.duration_seconds(bpm)
+
+
 @pytest.mark.parametrize(
     "invalid_string",
     [


### PR DESCRIPTION
Fixes #91.

`duration_seconds` guards BPM with `assert bpm > 0`, but its docstring documents a `ValueError` for non-positive BPM. Assertions are removed under `python -O`, so in an optimized run `bpm=0` falls through to `60.0 / bpm` and raises `ZeroDivisionError` instead. Switched to an explicit `raise ValueError`, matching how `fraction()` already validates its modifier. Added a regression test alongside the existing MusicalTime cases.