### PR TITLE
feat(realtime): PipeWire backend (#55)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **PipeWire realtime backend (#55).** `torchfx.realtime.PipeWireBackend` targets
+  PortAudio's PipeWire host (falling back to its PulseAudio host, which PipeWire
+  also serves), reusing the `SoundDeviceBackend` callback path — native low-latency
+  realtime on any modern Linux desktop with no new dependency beyond the `realtime`
+  group's `sounddevice`. Example: `examples/realtime_pipewire.py`.
+
 ## [0.8.0] - 2026-06-26
 
 ### Added

--- a/examples/realtime_pipewire.py
+++ b/examples/realtime_pipewire.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Real-time mic -> effects -> speakers over PipeWire (Linux).
+
+Needs: PipeWire running + `pip install torchfx[realtime]`. Ctrl-C to stop.
+"""
+
+import time
+
+import torchfx as fx
+from torchfx.realtime import PipeWireBackend, RealtimeProcessor, StreamConfig
+
+backend = PipeWireBackend()
+if not backend.is_available:
+    raise SystemExit("No PipeWire/Pulse PortAudio host found — is PipeWire running?")
+
+config = StreamConfig(sample_rate=48000, buffer_size=512, channels_in=1, channels_out=1)
+proc = RealtimeProcessor(
+    effects=[fx.effect.Gain(0.8), fx.effect.Reverb(room_size=0.6, mix=0.3, fs=48000)],
+    backend=backend,
+    config=config,
+)
+proc.start()
+try:
+    while True:
+        time.sleep(1)
+except KeyboardInterrupt:
+    proc.stop()

--- a/src/torchfx/realtime/__init__.py
+++ b/src/torchfx/realtime/__init__.py
@@ -79,6 +79,10 @@ def __getattr__(name: str) -> type:
         from torchfx.realtime.sounddevice_backend import SoundDeviceBackend
 
         return SoundDeviceBackend
+    if name == "PipeWireBackend":
+        from torchfx.realtime.pipewire_backend import PipeWireBackend
+
+        return PipeWireBackend
     raise AttributeError(f"module 'torchfx.realtime' has no attribute {name!r}")
 
 
@@ -96,6 +100,7 @@ __all__ = [
     "CudaGraphRunner",
     # Optional backends
     "SoundDeviceBackend",
+    "PipeWireBackend",
     # Exceptions
     "RealtimeError",
     "BackendNotAvailableError",

--- a/src/torchfx/realtime/pipewire_backend.py
+++ b/src/torchfx/realtime/pipewire_backend.py
@@ -1,0 +1,113 @@
+"""PipeWire audio backend for Linux.
+
+PipeWire is the default audio server on current Linux desktops. PortAudio
+(via ``sounddevice``) already exposes a PipeWire host API — and, where that is
+absent, PipeWire ships a PulseAudio-compatible server that PortAudio's Pulse
+host talks to. So a native, low-latency PipeWire callback path is one host
+selection away from the existing, battle-tested ``SoundDeviceBackend``.
+
+This backend therefore *is* ``SoundDeviceBackend`` with the host API pinned to
+PipeWire (falling back to Pulse): it reuses the whole tested callback engine,
+status mapping, and blocking read/write, and adds no dependency beyond the
+``sounddevice`` already in the ``realtime`` group.
+
+ponytail: PipeWire-via-PortAudio, not raw libpipewire. Covers every PipeWire
+desktop with ~no new code. Upgrade path if sub-PortAudio-buffer latency ever
+matters: a libpipewire ctypes/cffi client implementing AudioBackend directly.
+
+Examples
+--------
+>>> from torchfx.realtime import PipeWireBackend, StreamConfig
+>>> backend = PipeWireBackend()  # doctest: +SKIP
+>>> backend.open_stream(StreamConfig(channels_out=2), callback)  # doctest: +SKIP
+>>> backend.start()  # doctest: +SKIP
+
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from torchfx.realtime.backend import AudioCallback, StreamConfig, StreamDirection
+from torchfx.realtime.exceptions import StreamError
+from torchfx.realtime.sounddevice_backend import SoundDeviceBackend
+
+
+class PipeWireBackend(SoundDeviceBackend):
+    """Audio backend targeting the PipeWire (or Pulse) PortAudio host.
+
+    Raises
+    ------
+    BackendNotAvailableError
+        If ``sounddevice`` is not installed.
+
+    """
+
+    @property
+    def name(self) -> str:
+        """Return backend name."""
+        return "pipewire"
+
+    @property
+    def is_available(self) -> bool:
+        """Whether a PipeWire/Pulse PortAudio host is present."""
+        try:
+            return self._resolve_host() is not None
+        except Exception:
+            return False
+
+    def _resolve_host(self) -> tuple[int, dict[str, Any]] | None:
+        """Find the PortAudio host API backed by PipeWire (else Pulse)."""
+        apis = self._sd.query_hostapis()
+        for preferred in ("pipewire", "pulse"):
+            for idx, api in enumerate(apis):
+                if preferred in api["name"].lower():
+                    return idx, api
+        return None
+
+    def get_default_device(self, direction: StreamDirection) -> int | str:
+        """Return the PipeWire host's default device for ``direction``."""
+        host = self._resolve_host()
+        if host is None:
+            raise StreamError(
+                "No PipeWire/PulseAudio host API found in PortAudio",
+                suggestion="Ensure PipeWire is running and PortAudio has PipeWire/Pulse support",
+            )
+        _, api = host
+        key = (
+            "default_input_device"
+            if direction == StreamDirection.INPUT
+            else "default_output_device"
+        )
+        dev = api.get(key, -1)
+        if dev is None or dev < 0:
+            raise StreamError(f"No default PipeWire device for {direction.value}")
+        return int(dev)
+
+    def open_stream(self, config: StreamConfig, callback: AudioCallback | None = None) -> None:
+        """Open a stream on the PipeWire host, filling in its default devices."""
+        if config.device_in is None and config.device_out is None:
+            host = self._resolve_host()
+            if host is None:
+                raise StreamError(
+                    "No PipeWire/PulseAudio host API found in PortAudio",
+                    suggestion="Ensure PipeWire is running and PortAudio has PipeWire/Pulse support",
+                )
+            _, api = host
+            din = api.get("default_input_device", -1)
+            dout = api.get("default_output_device", -1)
+            config = replace(
+                config,
+                device_in=(
+                    din
+                    if config.channels_in > 0 and din is not None and din >= 0
+                    else config.device_in
+                ),
+                device_out=(
+                    dout
+                    if config.channels_out > 0 and dout is not None and dout >= 0
+                    else config.device_out
+                ),
+            )
+        super().open_stream(config, callback)

--- a/tests/test_pipewire_backend.py
+++ b/tests/test_pipewire_backend.py
@@ -1,0 +1,68 @@
+"""PipeWireBackend host-selection (#55).
+
+Mocks sounddevice — no audio hardware.
+
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from torchfx.realtime.backend import StreamConfig, StreamDirection
+from torchfx.realtime.exceptions import StreamError
+from torchfx.realtime.pipewire_backend import PipeWireBackend
+
+
+def _backend(hostapis, *, stream=None):
+    """A PipeWireBackend wired to a fake sounddevice module."""
+    b = PipeWireBackend.__new__(PipeWireBackend)  # skip get_sounddevice()
+    sd = MagicMock()
+    sd.query_hostapis.return_value = hostapis
+    sd.Stream.return_value = stream or MagicMock()
+    sd.OutputStream.return_value = stream or MagicMock()
+    sd.InputStream.return_value = stream or MagicMock()
+    b._sd = sd
+    b._stream = None
+    b._config = None
+    b._callback = None
+    from torchfx.realtime.backend import StreamState
+
+    b._state = StreamState.CLOSED
+    return b, sd
+
+
+PIPEWIRE_HOST = {"name": "PipeWire", "default_input_device": 3, "default_output_device": 4}
+PULSE_HOST = {"name": "PulseAudio", "default_input_device": 5, "default_output_device": 6}
+ALSA_HOST = {"name": "ALSA", "default_input_device": 0, "default_output_device": 1}
+
+
+def test_available_when_pipewire_host_present():
+    b, _ = _backend([ALSA_HOST, PIPEWIRE_HOST])
+    assert b.is_available
+    assert b.name == "pipewire"
+
+
+def test_unavailable_without_pipewire_or_pulse():
+    b, _ = _backend([ALSA_HOST])
+    assert not b.is_available
+    with pytest.raises(StreamError, match="No PipeWire"):
+        b.get_default_device(StreamDirection.OUTPUT)
+
+
+def test_prefers_pipewire_over_pulse():
+    b, _ = _backend([PULSE_HOST, PIPEWIRE_HOST])
+    assert b.get_default_device(StreamDirection.OUTPUT) == 4  # PipeWire, not Pulse
+
+
+def test_falls_back_to_pulse():
+    b, _ = _backend([ALSA_HOST, PULSE_HOST])
+    assert b.get_default_device(StreamDirection.INPUT) == 5
+
+
+def test_open_stream_routes_to_pipewire_default_device():
+    b, sd = _backend([ALSA_HOST, PIPEWIRE_HOST])
+    b.open_stream(StreamConfig(channels_in=0, channels_out=2))  # output-only
+    # The default PipeWire output device (4) must reach PortAudio.
+    assert sd.OutputStream.call_args.kwargs["device"] == 4


### PR DESCRIPTION
Closes #55.

`PipeWireBackend` pins PortAudio's PipeWire host (falling back to its PulseAudio host, which PipeWire also serves) and otherwise reuses the tested `SoundDeviceBackend` callback engine — native low-latency realtime on any modern Linux desktop, **no new dependency** beyond the `realtime` group's `sounddevice`.

- AudioBackend interface: inherited; overrides host resolution + default-device selection only.
- Mock-tested host selection (`tests/test_pipewire_backend.py`): pipewire-preferred, pulse fallback, unavailable-without-either, open_stream routes to the PW device.
- Example `examples/realtime_pipewire.py`; CHANGELOG under Unreleased.

ponytail: PipeWire-via-PortAudio, not raw libpipewire — every PipeWire desktop in ~40 lines. Upgrade path (libpipewire ctypes client) noted in the module docstring if sub-buffer latency is ever needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)